### PR TITLE
address all warnings and enable warnings as errors/fatal

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,8 @@
 ACLOCAL_AMFLAGS = -I m4
 
+AM_CFLAGS = -Werror -Wfatal-errors
+AM_CPPFLAGS = -Werror -Wfatal-errors
+
 SUBDIRS = . btech src
 
 # Our SVN-based magic for downloading and installing data files.

--- a/btech/Makefile.am
+++ b/btech/Makefile.am
@@ -1,5 +1,8 @@
 ACLOCAL_AMFLAGS = -I m4
 
+AM_CFLAGS = -Werror -Wfatal-errors
+AM_CPPFLAGS = -Werror -Wfatal-errors
+
 if BTPR_MUX1
 endif
 

--- a/btech/btfi/Codec.cc
+++ b/btech/btfi/Codec.cc
@@ -1130,12 +1130,6 @@ Encoder::writeNonEmptyOctets_len_bit2(FI_PInt32 len)
 	assert(getBitOffset() == 1); // C.22.2
 	assert(len <= FI_PINT32_MAX);
 
-	if (len > FI_UINT_TO_PINT(FI_LENGTH_MAX)) {
-		// Will overflow.
-		// FIXME: Implementation restriction.
-		throw UnsupportedOperationException ();
-	}
-
 	FI_Octet *w_buf;
 
 	if (len <= FI_UINT_TO_PINT(64)) {
@@ -1221,12 +1215,6 @@ Decoder::readNonEmptyOctets_len_bit2(FI_PInt32& len)
 		tmp_len += FI_UINT_TO_PINT(1);
 	}
 
-	if (tmp_len > FI_UINT_TO_PINT(FI_LENGTH_MAX)) {
-		// Will overflow.
-		// FIXME: Implementation restriction.
-		throw UnsupportedOperationException ();
-	}
-
 	readBits(7);
 
 	len = tmp_len;
@@ -1240,12 +1228,6 @@ Encoder::writeNonEmptyOctets_len_bit5(FI_PInt32 len)
 {
 	assert(getBitOffset() == 4); // C.23.2
 	assert(len <= FI_PINT32_MAX);
-
-	if (len > FI_UINT_TO_PINT(FI_LENGTH_MAX)) {
-		// Will overflow.
-		// FIXME: Implementation restriction.
-		throw UnsupportedOperationException ();
-	}
 
 	FI_Octet *w_buf;
 
@@ -1332,12 +1314,6 @@ Decoder::readNonEmptyOctets_len_bit5(FI_PInt32& len)
 		tmp_len += FI_UINT_TO_PINT(1);
 	}
 
-	if (tmp_len > FI_UINT_TO_PINT(FI_LENGTH_MAX)) {
-		// Will overflow.
-		// FIXME: Implementation restriction.
-		throw UnsupportedOperationException ();
-	}
-
 	readBits(4);
 
 	len = tmp_len;
@@ -1351,12 +1327,6 @@ Encoder::writeNonEmptyOctets_len_bit7(FI_PInt32 len)
 {
 	assert(getBitOffset() == 6); // C.24.2
 	assert(len <= FI_PINT32_MAX);
-
-	if (len > FI_UINT_TO_PINT(FI_LENGTH_MAX)) {
-		// Will overflow.
-		// FIXME: Implementation restriction.
-		throw UnsupportedOperationException ();
-	}
 
 	FI_Octet *w_buf;
 
@@ -1441,12 +1411,6 @@ Decoder::readNonEmptyOctets_len_bit7(FI_PInt32& len)
 		tmp_len = getBits() & FI_BITS(,,,,,,/*0*/,1);
 
 		tmp_len += FI_UINT_TO_PINT(1);
-	}
-
-	if (tmp_len > FI_UINT_TO_PINT(FI_LENGTH_MAX)) {
-		// Will overflow.
-		// FIXME: Implementation restriction.
-		throw UnsupportedOperationException ();
 	}
 
 	readBits(2);

--- a/btech/src/Makefile.am
+++ b/btech/src/Makefile.am
@@ -1,5 +1,5 @@
 AM_CPPFLAGS = $(BTPR_INCLUDE) -I$(srcdir)/include -I$(srcdir)/btech \
-	-I$(top_srcdir)/btfi/include
+	-I$(top_srcdir)/btfi/include -Werror -Wfatal-errors
 
 if BTPR_MUX1
 BTPR_INCLUDE = -I$(top_srcdir)/../include -I$(top_srcdir)/../src

--- a/btech/src/btech/aero.move.c
+++ b/btech/src/btech/aero.move.c
@@ -12,6 +12,7 @@
 
 #include <math.h>
 #include "muxevent.h"
+#include "glue.h"
 #include "mech.h"
 #include "mech.events.h"
 #include "p.mech.sensor.h"
@@ -290,7 +291,7 @@ int ImproperLZ(MECH * mech, int x, int y)
 	improper_lz_status = 0;
 	improper_lz_height = Elevation(map, x, y);
 	visit_neighbor_hexes(map, x, y, ImproperLZ_callback);
-	
+
 	if(improper_lz_status != 6)
 		if(mudconf.btech_blzmapmode == 0)
 			return UNEVEN_TERRAIN;
@@ -415,7 +416,7 @@ void ds_BridgeHit(MECH * mech)
 
 void aero_UpdateHeading(MECH * mech)
 {
-	/* Heading things are done in speed now, odd as though it might 
+	/* Heading things are done in speed now, odd as though it might
 	   seem */
 	if(SpheroidDS(mech))
 		UpdateHeading(mech);
@@ -536,7 +537,7 @@ int FuelCheck(MECH * mech)
 		return 0;
 	if(fabs(MechSpeed(mech)) > MMaxSpeed(mech)) {
 		if(MechZ(mech) < ATMO_Z)
-			fuelcost = abs(MechSpeed(mech) / MMaxSpeed(mech));
+			fuelcost = (int)fabs(MechSpeed(mech) / MMaxSpeed(mech));
 	} else if(fabs(MechSpeed(mech)) < MP1 &&
 			  fabs(MechVerticalSpeed(mech)) < MP2)
 		if(Number(0, 1) == 0)

--- a/btech/src/btech/autopilot_ai.c
+++ b/btech/src/btech/autopilot_ai.c
@@ -6,7 +6,7 @@
  *
  *  Copyright (c) 1998 Markus Stenberg
  *  Copyright (c) 1998-2002 Thomas Wouters
- *  Copyright (c) 2000-2002 Cord Awtry 
+ *  Copyright (c) 2000-2002 Cord Awtry
  *       All rights reserved
  *
  * Created: Thu Mar 12 18:36:33 1998 fingon
@@ -20,6 +20,7 @@
 
 #include <math.h>
 
+#include "glue.h"
 #include "mech.h"
 #include "autopilot.h"
 #include "p.autopilot_command.h"
@@ -1163,7 +1164,7 @@ int auto_astar_generate_path(AUTO * autopilot, MECH * mech, short end_x,
 			/* Generate hexoffset for the child node */
 			hexoffset = HexOffSet(map_x2, map_y2);
 
-			/* Check to see if its in the closed list 
+			/* Check to see if its in the closed list
 			 * if so just ignore it */
 			if(CheckHexBit(closed_list_bitfield, hexoffset))
 				continue;
@@ -1196,23 +1197,23 @@ int auto_astar_generate_path(AUTO * autopilot, MECH * mech, short end_x,
 			 * and multiply by 100 */
 			/*! \todo {Add in something for elevation cost} */
 
-			/* Get the end hex in real coords, using the old variables 
+			/* Get the end hex in real coords, using the old variables
 			 * to store the values */
 			MapCoordToRealCoord(end_x, end_y, &x1, &y1);
 
-			/* Re-using the x2 and y2 values we calc'd for the child hex 
+			/* Re-using the x2 and y2 values we calc'd for the child hex
 			 * to find the range between the child hex and end hex */
 			child_h_score = 100 * FindHexRange(x2, y2, x1, y1);
 
 			/* Lets attempt to avoid hexes that already have our friendlies in it (Stack Check) */
-			if(mechs_in_hex(map, map_x2, map_y2, 1, MechTeam(mech)) > 2) 
+			if(mechs_in_hex(map, map_x2, map_y2, 1, MechTeam(mech)) > 2)
 				child_g_score +=150;
 
 			/* Now add in some modifiers for terrain */
 			switch (GetTerrain(map, map_x2, map_y2)) {
 			case LIGHT_FOREST:
 
-				/* Don't bother trying to enter a light forest 
+				/* Don't bother trying to enter a light forest
 				 * hex unless we can */
 				if((MechType(mech) == CLASS_VEH_GROUND) &&
 				   (MechMove(mech) != MOVE_TRACK))
@@ -1272,7 +1273,7 @@ int auto_astar_generate_path(AUTO * autopilot, MECH * mech, short end_x,
 														 (void *) hexoffset);
 
 				/* Now compare the 'g_scores' to determine shortest path */
-				/* If g_score is lower, this means better path 
+				/* If g_score is lower, this means better path
 				 * from the current parent node */
 				if(child_g_score < temp_astar_node->g_score) {
 
@@ -1308,7 +1309,7 @@ int auto_astar_generate_path(AUTO * autopilot, MECH * mech, short end_x,
 
 				} else {
 
-					/* Don't need to do anything so we can skip 
+					/* Don't need to do anything so we can skip
 					 * to the next node */
 					continue;
 

--- a/btech/src/btech/autopilot_autogun.c
+++ b/btech/src/btech/autopilot_autogun.c
@@ -93,7 +93,7 @@ int SearchLightInRange(MECH * mech, MAP * map)
 					/* Slite on, arced, but LoS blocked */
 					return 4;
 
-			} else if(!MechStatus(target) & SLITE_ON &&
+			} else if(!(MechStatus(target) & SLITE_ON) &&
 					  InWeaponArc(target, MechFX(mech),
 								  MechFY(mech)) & FORWARDARC) {
 
@@ -111,7 +111,7 @@ int SearchLightInRange(MECH * mech, MAP * map)
 					return 6;
 			}
 
-			/* Slite is in range of you, but apparently not arced on you. 
+			/* Slite is in range of you, but apparently not arced on you.
 			 * Return tells wether on or off */
 			return (MechStatus(target) & SLITE_ON ? 1 : 2);
 		}
@@ -168,10 +168,10 @@ void auto_sensor_event(AUTO *autopilot)
 		dprintk("mynum is bad!");
 		return;
 	}
-			 
-	
+
+
 	MECH *mech = (MECH *) autopilot->mymech;
-	
+
 	/* Make sure its a MECH Xcode Object and the AI is
 	 * an AUTOPILOT Xcode Object */
         /* Basic checks */
@@ -183,7 +183,7 @@ void auto_sensor_event(AUTO *autopilot)
                 dprintk("ai is bad!");
                 return;
         }
-			
+
 	if(!IsMech(mech->mynum) || !IsAuto(autopilot->mynum))
 		return;
 
@@ -211,7 +211,7 @@ void auto_sensor_event(AUTO *autopilot)
 		Zombify(autopilot);
 		return;
 	}
-	
+
 	/* Get the target if there is one */
 	if(MechTarget(mech) > 0)
 		target = getMech(MechTarget(mech));
@@ -457,7 +457,7 @@ int auto_calc_weapon_score(int weapon_db_number, int range)
 
 	/* For the modifiers I assumed best was approx 550
 	 *
-	 * So for SR, chance of hitting is roughly 92% which is 506 rounded to 500 
+	 * So for SR, chance of hitting is roughly 92% which is 506 rounded to 500
 	 * For MR, its 72%, so 390 and LR its 41% its 225 */
 
 	/* Assume default values */
@@ -583,7 +583,7 @@ void auto_update_profile_event(AUTO *autopilot) {
 	if(Destroyed(mech)) {
 		return;
 	}
-    
+
 	/* Log Message */
 	print_autogun_log(autopilot, "Profiling Unit #%d", mech->mynum);
 
@@ -671,7 +671,7 @@ void auto_update_profile_event(AUTO *autopilot) {
 
 	}
 
-	/* Now build the profile array, basicly loop through 
+	/* Now build the profile array, basicly loop through
 	 * all the current avail weapons, get its max range,
 	 * then loop through ranges and for each range add it
 	 * to profile */
@@ -1232,7 +1232,7 @@ void auto_gun_event(AUTO *autopilot)
 						  autopilot->target);
 
 	}
-	
+
 	/* Primary target isn't in LOS. Let's re-run in 5s */
 	if(!(MechToMech_LOSFlag(map, mech, target) & MECHLOSFLAG_SEEN)) {
 		autopilot->target = -1;
@@ -1469,7 +1469,7 @@ void auto_gun_event(AUTO *autopilot)
 					rleg_bth = 99;
 				}
 
-				/* Now kick depending on which one would be better 
+				/* Now kick depending on which one would be better
 				 * to kick with */
 				if(rleg_bth <= lleg_bth) {
 					snprintf(buffer, LBUF_SIZE, "r %c%c",
@@ -1590,7 +1590,7 @@ void auto_gun_event(AUTO *autopilot)
 					rleg_bth = 99;
 				}
 
-				/* Now kick depending on which one would be better 
+				/* Now kick depending on which one would be better
 				 * to kick with */
 				if(rleg_bth <= lleg_bth) {
 					snprintf(buffer, LBUF_SIZE, "r %c%c",
@@ -1745,7 +1745,7 @@ void auto_gun_event(AUTO *autopilot)
 											  range_scores[(int) range]);
 				continue;
 			}
-			
+
 			/* No sense trying to fire Stinger missiles if the target isn't airborne/jumping */
 
 			if((GetPartAmmoMode(mech, temp_weapon_node->section, temp_weapon_node->critical) & STINGER_MODE) && target
@@ -1758,7 +1758,7 @@ void auto_gun_event(AUTO *autopilot)
 											range_scores[(int) range]);
 				continue;
 			}
-	
+
 
 			/* Check heat levels, since the heat isn't updated untill we're done
 			 * we have to manage the heat ourselves */
@@ -1873,7 +1873,7 @@ void auto_gun_event(AUTO *autopilot)
 
 					}
 
-					/* ELSE: Weapon is rear mounted so don't need to 
+					/* ELSE: Weapon is rear mounted so don't need to
 					 * do anything */
 
 				} else if(what_arc & LSIDEARC) {
@@ -2091,8 +2091,8 @@ void auto_gun_event(AUTO *autopilot)
 	/* Log It */
 	print_autogun_log(autopilot, "Autogun - End Weapon Attack Phase");
 
-	/* Setup chasetarg 
-	 * 
+	/* Setup chasetarg
+	 *
 	 * Since chasetarget uses follow but we don't want follow getting
 	 * messed up if its following a normal target.  We define our own
 	 * follow (basicly its follow but with the command name chasetarget */

--- a/btech/src/btech/autopilot_commands.c
+++ b/btech/src/btech/autopilot_commands.c
@@ -15,6 +15,7 @@
  */
 
 #include <math.h>
+#include "glue.h"
 #include "mech.h"
 #include "mech.events.h"
 #include "autopilot.h"
@@ -308,7 +309,7 @@ void auto_set_chasetarget_mode(AUTO * autopilot, int mode)
 
 	case AUTO_CHASETARGET_SAVE:
 
-		/* If we are chasing a target turn this off 
+		/* If we are chasing a target turn this off
 		 * but save it */
 		if(ChasingTarget(autopilot)) {
 
@@ -1076,7 +1077,7 @@ void auto_goto_event(MUXEVENT * e)
 	}
 	free(argument);
 
-	if(MechX(mech) == tx && MechY(mech) == ty && abs(MechSpeed(mech)) < 0.5) {
+	if(MechX(mech) == tx && MechY(mech) == ty && fabs(MechSpeed(mech)) < 0.5) {
 
 		/* We've reached this goal! Time for next one. */
 		ai_set_speed(mech, autopilot, 0);
@@ -1295,7 +1296,7 @@ void auto_dumbgoto_event(MUXEVENT * muxevent)
 	free(argument);
 
 	/* If we're at the target hex - stop */
-	if(MechX(mech) == tx && MechY(mech) == ty && abs(MechSpeed(mech)) < 0.5) {
+	if(MechX(mech) == tx && MechY(mech) == ty && fabs(MechSpeed(mech)) < 0.5) {
 
 		/* We've reached this goal! Time for next one. */
 		ai_set_speed(mech, autopilot, 0);

--- a/btech/src/btech/autopilot_core.c
+++ b/btech/src/btech/autopilot_core.c
@@ -8,6 +8,8 @@
  *
  */
 
+
+#include "glue.h"
 #include "mech.h"
 #include "mech.events.h"
 #include "autopilot.h"
@@ -164,7 +166,7 @@ static command_node *auto_read_command_node(FILE * file)
 
 }
 
-/* 
+/*
  * Saves the current command list from the AI to
  * a file.  Called by SaveSpecialObjects from
  * glue.c
@@ -266,7 +268,7 @@ void auto_load_commands(FILE * file, AUTO * autopilot)
 
 }
 
-/* 
+/*
    The Autopilot command interface
 
    addcommand <name> [args]
@@ -450,7 +452,7 @@ void auto_addcommand(dbref player, void *data, char *buffer)
 {
 
 	AUTO *autopilot = (AUTO *) data;
-	char *args[AUTOPILOT_MAX_ARGS];	/* args[0] is the command the rest are 
+	char *args[AUTOPILOT_MAX_ARGS];	/* args[0] is the command the rest are
 									   args for the command */
 	char *command;				/* temp string to get the name of the command */
 	int argc;
@@ -772,7 +774,7 @@ void auto_goto_next_command(AUTO * autopilot, int time)
 
 /*
  * Get the argument for a given command position and argument number
- * Remember to free the string that this returns after use 
+ * Remember to free the string that this returns after use
  */
 char *auto_get_command_arg(AUTO * autopilot, int command_number,
 						   int arg_number)
@@ -967,7 +969,7 @@ extern unsigned int global_tick;
 void auto_heartbeat(AUTO *autopilot) {
     if(!autopilot->mymech) return;
     auto_sensor_event(autopilot);
-    if(autopilot->weaplist == NULL || global_tick % AUTO_PROFILE_TICK == 0)  
+    if(autopilot->weaplist == NULL || global_tick % AUTO_PROFILE_TICK == 0)
         auto_update_profile_event(autopilot);
     auto_gun_event(autopilot);
 }

--- a/btech/src/btech/autopilot_radio.c
+++ b/btech/src/btech/autopilot_radio.c
@@ -17,6 +17,7 @@
 /* Most of the BattleSheep(tm) code is here.. */
 
 #include <math.h>
+#include "glue.h"
 #include "mech.h"
 #include "autopilot.h"
 #include "spath.h"
@@ -49,7 +50,7 @@ void sendchannelstuff(MECH * mech, int freq, char *msg);
 #define BACMD(name) char * name (AUTO *autopilot, MECH *mech, char **args, int argc, int chn)
 #define ACMD(name) static BACMD(name)
 
-/* 
+/*
  * Master list of AI - radio commands
  */
 struct {
@@ -444,7 +445,7 @@ void auto_radio_command_heading(AUTO * autopilot, MECH * mech,
 	mech_heading(autopilot->mynum, mech, buffer);
 	strcpy(buffer, "0");
 	mech_speed(autopilot->mynum, mech, buffer);
-	snprintf(buffer, LBUF_SIZE, "stopped and heading changed to %d", heading);
+	snprintf(buffer, SBUF_SIZE, "stopped and heading changed to %d", heading);
 
 }
 
@@ -502,7 +503,7 @@ void auto_radio_command_hide(AUTO * autopilot, MECH * mech,
 }
 
 /*
- * Radio command to force AI to jump either on a target or 
+ * Radio command to force AI to jump either on a target or
  * in a given direction range
  */
 void auto_radio_command_jumpjet(AUTO * autopilot, MECH * mech,
@@ -513,7 +514,7 @@ void auto_radio_command_jumpjet(AUTO * autopilot, MECH * mech,
 	char buffer[SBUF_SIZE];
 	int bear, rng;
 
-	if(!abs(MechJumpSpeed(mech))) {
+	if(!(int)fabs(MechJumpSpeed(mech))) {
 		snprintf(mesg, LBUF_SIZE, "!I don't do hiphop and jump around");
 		return;
 	}

--- a/btech/src/btech/btechstats.c
+++ b/btech/src/btech/btechstats.c
@@ -388,7 +388,7 @@ int char_gainxpbycode(dbref player, int code, int amount, int override)
 		return 0;
 	s = retrieve_stats(player, VALUES_SKILLS | VALUES_ATTRS);
 /* allow override of setting xp quickly. useful in chargen situations and only settable via that
- * Regular skill gains still check SK_XP and last used within 30s to keep from spamming 
+ * Regular skill gains still check SK_XP and last used within 30s to keep from spamming
  */
 	if(override == 0)
 		if(!((mudstate.now > (s->last_use[code] + 30)) ||
@@ -947,7 +947,7 @@ int handlemwconc(MECH * mech, int initial)
 				if(!Destroyed(mech))
 					DestroyMech(mech, mech, 0, KILL_TYPE_MWDAMAGE);
 
-				MechPilot(mech) = -1;	
+				MechPilot(mech) = -1;
 				MechSpeed(mech) = 0.;
 				MechDesiredSpeed(mech) = 0.;
 				return 0;
@@ -1332,7 +1332,7 @@ float getPilotBVMod(MECH * mech, int weapindx)
 	 * (that's <gun skill>+ <pilot skill>+)
 	 */
 
-	int zeroPilotBaseSkills[] =
+	float zeroPilotBaseSkills[] =
 		{ 2.05, 1.85, 1.65, 1.45, 1.25, 1.15, 1.05, .95 };
 
 	int myGSkill = FindPilotGunnery(mech, weapindx);
@@ -1380,7 +1380,7 @@ void AccumulateGunXP(dbref pilot, MECH * attacker, MECH * wounded,
 	/* No XP for zero'd mechas */
 	for(i = 0; i < NUM_SECTIONS; i++)
 		j -= SectIsDestroyed(wounded, i);
-	
+
 	if( j < 1)
 		return;
 
@@ -1429,7 +1429,7 @@ void AccumulateGunXP(dbref pilot, MECH * attacker, MECH * wounded,
 
 	if(mudconf.btech_xp_bthmod) {
 		if(!(bth >= 3 && bth <= 12)) {
-			if(mudconf.btech_noisy_xpgain) 
+			if(mudconf.btech_noisy_xpgain)
 				SendXP(tprintf("#%d in #%d 1 noxp #%d", pilot, attacker->mynum, wounded->mynum));
 			return;				/* sure hits aren't interesting */
 		}
@@ -1489,7 +1489,7 @@ void AccumulateGunXP(dbref pilot, MECH * attacker, MECH * wounded,
 
 	if(mudconf.btech_perunit_xpmod)
 		multiplier = multiplier * MechXPMod(attacker); /* Per unit XP Mod. Defaults to 1 anyways */
-	
+
 	/* Change the Cap to be variable depending on what a mux wants */
 
 	xp = BOUNDED(1, (int) (multiplier * damage / 100), mudconf.btech_xpgain_cap);
@@ -1675,32 +1675,32 @@ void fun_btsetcharvalue(char *buff, char **bufc, dbref player, dbref cause,
 								char_values[targetcode].name, char_getvaluebycode(target, targetcode));
 				break;
 
-			case 1: 
+			case 1:
 				/* This is the + value of said skill
 				 * Also known as the ToHit Roll. This is not the 'Skill Level'
 				 * I.e. Setting someone's Gun-Bmech with this to 5 with a Physical Attribute of 7+
 				 * will give you Level 2 Gun-Bmech (5+) */
-				
-			
+
+
 				char_setvaluebycode(target, targetcode, 0)
 				targetvalue =
 					char_getskilltargetbycode(target, targetcode,
 											  0) - targetvalue;
 
-				/* Handle a wierd code race issue. target shouldn't be negative in this case anyways */			
+				/* Handle a wierd code race issue. target shouldn't be negative in this case anyways */
 				if (targetvalue >= 0) {
 					char_setvaluebycode(target,targetcode,targetvalue);
 				}
 				else {
 					char_setvaluebycode(target,targetcode,0);
 				}
-					
+
 				safe_tprintf_str(buff, bufc, "%s's %s set to %d", Name(target),
 							char_values[targetcode].name, targetvalue >=0 ? char_getvaluebycode(target, targetcode) : 0);
-		
+
 				break;
-			
-			case 3: 
+
+			case 3:
 				/* Set the XP Amount for this skill */
 				char_gainxpbycode(target, targetcode, targetvalue - char_getxpbycode(target, targetcode), 1);
 
@@ -1710,7 +1710,7 @@ void fun_btsetcharvalue(char *buff, char **bufc, dbref player, dbref cause,
 						targetvalue);
 
 				break;
-			
+
 			default:
 				/* Any other flaggo value will addxp for the skill */
  				char_gainxpbycode(target, targetcode, targetvalue,1);
@@ -1723,7 +1723,7 @@ void fun_btsetcharvalue(char *buff, char **bufc, dbref player, dbref cause,
 
 				break;
 		}
-	
+
 }
 
 /* ----------------------------------------------------------------------
@@ -2041,7 +2041,7 @@ void debug_setxplevel(dbref player, void *data, char *buffer)
 			 char_getvaluecode(args[0])) < 0, "That isn't any charvalue!");
 	DOCHECK(char_values[code].type != CHAR_SKILL, "That isn't any skill!");
 	char_values[code].xpthreshold = xpt;
-    log_error(LOG_WIZARD, "WIZ", "CHANGE", "Exp threshold for %s changed to %d by #%d", 
+    log_error(LOG_WIZARD, "WIZ", "CHANGE", "Exp threshold for %s changed to %d by #%d",
 						 char_values[code].name, xpt, player);
 }
 

--- a/btech/src/btech/btmacros.h
+++ b/btech/src/btech/btmacros.h
@@ -486,7 +486,7 @@ do { if (Started(a) && !Destroyed(a) && a->rd.last_weapon_recycle != muxevent_ti
 #define StopPerformingAction(a) (MechStatus(a) &= ~PERFORMING_ACTION)
 
 #define MakeMechFall(a)      MechStatus(a) |= FALLEN;FallCentersTorso(a);MarkForLOSUpdate(a);MechFloods(a);StopStand(a);StopHullDown(a);MechStatus(a) &= ~HULLDOWN;if(mudconf.btech_newstagger) {ClearAllStaggerDamage(a);};
-	  
+
 #define FallCentersTorso(a)  MechStatus(a) &= ~(TORSO_RIGHT|TORSO_LEFT|FLIPPED_ARMS)
 #define MakeMechStand(a)     MechStatus(a) &= ~FALLEN;MarkForLOSUpdate(a)
 #define StandMechTime(a)     (30 / BOUNDED(1,(MechMaxSpeed(a)/MP2),30))
@@ -886,5 +886,5 @@ if (FlyingT(mech)) { \
 #define Dodging(a)		(MechStatus2(a) & DODGING)
 #define SideSlipping(a)		muxevent_count_type_data(EVENT_SIDESLIP, (void *) a)
 #define StopSideslip(a)		muxevent_remove_type_data(EVENT_SIDESLIP, (void *) a)
-											   
+
 #endif				/* BTMACROS_H */

--- a/btech/src/btech/crit.c
+++ b/btech/src/btech/crit.c
@@ -12,12 +12,14 @@
 #include "config.h"
 #include "externs.h"
 #include "db.h"
+#include "glue.h"
 #include "mech.h"
 #include "btmacros.h"
 #include "mech.events.h"
 #include "mech.sensor.h"
 #include "failures.h"
 #include "p.econ_cmds.h"
+#include "p.mech.tech.commands.h"
 #include "p.mech.update.h"
 #include "p.bsuit.h"
 #include "autopilot.h"
@@ -373,7 +375,7 @@ int handleWeaponCrit(MECH * attacker, MECH * wounded, int hitloc,
 			sprintf(msgbuf, "'s %s is covered in a large electrical discharge!", locname);
 			MechLOSBroadcast(wounded, msgbuf);
 		}
-                 
+
 		DestroyWeapon(wounded, hitloc, critType, wFirstCrit, wMaxCrits,
 					  wMaxCrits);
 
@@ -384,7 +386,7 @@ int handleWeaponCrit(MECH * attacker, MECH * wounded, int hitloc,
 		}
 /* Rule Reference: BMR Revised, Page 16-17 (Ammo Explosion=2 Bruise) */
 /* Rule Reference: Total Warfare, Page 41 (Ammo Explosion=2 Bruise) */
-	
+
 		if(MechType(wounded) != CLASS_BSUIT) {
 			mech_notify(wounded, MECHPILOT, "You take personal injury from the weapon's explosion!");
 
@@ -428,7 +430,7 @@ int handleWeaponCrit(MECH * attacker, MECH * wounded, int hitloc,
 						damage);
 
 			if(!Destroyed(wounded)) {
-				sprintf(msgbuf, " loses a launcher in a brilliant explosion!", locname);
+				sprintf(msgbuf, " loses a launcher in a brilliant explosion!");
 				MechLOSBroadcast(wounded, msgbuf);
 			}
 
@@ -1828,7 +1830,7 @@ int HandleMechCrit(MECH * wounded, MECH * attacker, int LOS, int hitloc,
 				break;
 			}					// end switch() - Part Names
 		}						// end if()
-		
+
 		if(IsWeapon(critType)) {
 			mech_printf(wounded, MECHALL, "Part of your non-working %s has been hit!", &MechWeapons[Weapon2I(critType)].name[3]);
 		}
@@ -1867,7 +1869,7 @@ int HandleMechCrit(MECH * wounded, MECH * attacker, int LOS, int hitloc,
 			mech_notify(wounded, MECHALL,
 						"Your cockpit is destroyed, your blood boils, and your body is fried! %cyYou're dead!%cn");
 			if(!Destroyed(wounded)) {
-				DestroyMech(wounded, attacker, 0, KILL_TYPE_COCKPIT);		
+				DestroyMech(wounded, attacker, 0, KILL_TYPE_COCKPIT);
 			}
 
 			if(LOS && attacker)
@@ -1974,7 +1976,7 @@ int HandleMechCrit(MECH * wounded, MECH * attacker, int LOS, int hitloc,
 			}
 			break;
 		case TARGETING_COMPUTER:
-			if(!MechCritStatus(wounded) & TC_DESTROYED) {
+			if(!(MechCritStatus(wounded) & TC_DESTROYED)) {
 				mech_notify(wounded, MECHALL,
 							"Your targeting computer is destroyed!");
 				MechCritStatus(wounded) |= TC_DESTROYED;
@@ -1983,7 +1985,7 @@ int HandleMechCrit(MECH * wounded, MECH * attacker, int LOS, int hitloc,
 		case GYRO:
 			/* Hardened Gyro's take one extra hit before damaged */
 			if(MechSpecials2(wounded) & HDGYRO_TECH)
-				if(!MechCritStatus2(wounded) & HDGYRO_DAMAGED) {
+				if(!(MechCritStatus2(wounded) & HDGYRO_DAMAGED)) {
 					sprintf(msgbuf, "emits a screech as its "
 							"hardened gyro buckles slightly!");
 					MechLOSBroadcast(wounded, msgbuf);
@@ -2104,7 +2106,7 @@ int HandleMechCrit(MECH * wounded, MECH * attacker, int LOS, int hitloc,
 					mech_notify(mech, MECHALL,"The hit causes your tow line to let go!");
 					MechLOSBroadcast(mech,"'s tow lines release and flap freely behind it!");
 					mech_dropoff(GOD, mech, "");
-				}		
+				}
 				NormalizeLocActuatorCrits(wounded, hitloc);
 			} else if(tLocIsLeg) {
 				mech_notify(wounded, MECHALL,

--- a/btech/src/btech/ds.bay.c
+++ b/btech/src/btech/ds.bay.c
@@ -259,7 +259,7 @@ void mech_enterbay(dbref player, void *data, char *buffer)
 			"Speed difference's too large to enter!");
 	DOCHECK(MechZ(ds) != MechZ(mech),
 			"Get to same elevation before thinking about entering!");
-	DOCHECK(abs(MechVerticalSpeed(mech) - MechVerticalSpeed(ds)) > 10,
+	DOCHECK(fabs(MechVerticalSpeed(mech) - MechVerticalSpeed(ds)) > 10,
 			"Vertical speed difference is too great to enter safely!");
 	DOCHECK(MechType(mech) == CLASS_MECH && !MechIsQuad(mech) &&
 			(IsMechLegLess(mech)), "Without legs? Are you kidding?");

--- a/btech/src/btech/econ_cmds.c
+++ b/btech/src/btech/econ_cmds.c
@@ -17,6 +17,8 @@
  */
 
 #include <stdio.h>
+
+#include "glue.h"
 #include "mech.h"
 #include "coolmenu.h"
 #include "math.h"
@@ -259,7 +261,7 @@ static void stuff_change_sub(dbref player, char *buffer, dbref loc1,
 	argc = mech_parseattributes(buffer, args, 2);
 	DOCHECK(argc < 2, "Invalid number of arguments!");
 
-	/* 
+	/*
 	 * If we hit the max amount of parts addable at once, set quantity
 	 * to add to max.
 	 */

--- a/btech/src/btech/eject.c
+++ b/btech/src/btech/eject.c
@@ -13,6 +13,7 @@
 
 /* Ejection code */
 #include <math.h>
+#include "glue.h"
 #include "mech.h"
 #include "mech.events.h"
 #include "p.btechstats.h"
@@ -348,7 +349,7 @@ void mech_udisembark(dbref player, void *data, char *buffer)
 	DOCHECK(under_repairs,
 			"This 'Mech is still under repairs (see checkstatus for more info)");
 
-	DOCHECK(abs(MechSpeed(target)) > WalkingSpeed(MMaxSpeed(target)),
+	DOCHECK(fabs(MechSpeed(target)) > WalkingSpeed(MMaxSpeed(target)),
 			"You cannot leave while the carrier is moving faster than walk speed!");
 
 	/* Carry out the disembarking. */
@@ -509,7 +510,7 @@ void mech_embark(dbref player, void *data, char *buffer)
 
 			/* Trigger FAIL & AFAIL */
 			memset(fail_mesg, 0, sizeof(fail_mesg));
-			snprintf(fail_mesg, LBUF_SIZE,
+			snprintf(fail_mesg, SBUF_SIZE,
 					 "That unit's bay doors are locked.");
 
 			did_it(player, target->mynum, A_FAIL, fail_mesg, 0, NULL, A_AFAIL,
@@ -584,7 +585,7 @@ void mech_embark(dbref player, void *data, char *buffer)
 
 		/* Trigger FAIL & AFAIL */
 		memset(fail_mesg, 0, sizeof(fail_mesg));
-		snprintf(fail_mesg, LBUF_SIZE, "That unit's bay doors are locked.");
+		snprintf(fail_mesg, SBUF_SIZE, "That unit's bay doors are locked.");
 
 		did_it(player, target->mynum, A_FAIL, fail_mesg, 0, NULL, A_AFAIL,
 			   (char **) NULL, 0);
@@ -736,7 +737,7 @@ void autoeject(dbref player, MECH * mech, int tIsBSuit)
 	initialize_pc(player, m);
 	MechPilot(m) = player;
 	MechTeam(m) = MechTeam(mech);
-/* MUDCONF THIS LATER (and fix not copying digital) 
+/* MUDCONF THIS LATER (and fix not copying digital)
 #ifdef COPY_CHANS_ON_EJECT
 	memcpy(m->freq, mech->freq, FREQS * sizeof(m->freq[0]));
 	memcpy(m->freqmodes, mech->freqmodes, FREQS * sizeof(m->freqmodes[0]));

--- a/btech/src/btech/failures.c
+++ b/btech/src/btech/failures.c
@@ -2,9 +2,9 @@
 /* This is the code that runs the parts failures.
    Written by: Nim
    9-28-96
-   
+
    Parts copyright (c) 2000-2002 Thomas Wouters
-   
+
  */
 
 /*
@@ -22,6 +22,7 @@
 #include "failures.h"
 #include "mech.events.h"
 #include "p.mech.startup.h"
+#include "p.mech.update.h"
 
 extern int num_def_weapons;
 

--- a/btech/src/btech/hudinfo.c
+++ b/btech/src/btech/hudinfo.c
@@ -12,6 +12,7 @@
 #include "interface.h"
 
 #include "muxevent.h"
+#include "glue.h"
 #include "mech.h"
 #include "map.h"
 #include "map.los.h"
@@ -228,7 +229,7 @@ static void hud_generalstatus(DESC * d, MECH * mech, char *msgclass,
 //	else {
 //		strcpy(targetID, "-");
 //	}
-	
+
 
 	sprintf(response,
 			"%s,%d,%d,%d,%d,%d,%.2f,%.2f,%d,%d,%s,%.2f,%.2f,%.3f,%d,%s,%s,%s,%s,%s",
@@ -239,8 +240,8 @@ static void hud_generalstatus(DESC * d, MECH * mech, char *msgclass,
 			(int) (10 * MechMinusHeat(mech)),
 			fuel, MechVerticalSpeed(mech), MechVerticalSpeed(mech),
 			rtc, btc, tstat, getStatusString(mech, 2), jumpx, jumpy,
-//			MechTarget(mech) != -1 ? targetID:"-"); 
-			"-");			
+//			MechTarget(mech) != -1 ? targetID:"-");
+			"-");
 
 	hudinfo_notify(d, msgclass, "R", response);
 }
@@ -1174,7 +1175,7 @@ static void hud_tactical(DESC * d, MECH * mech, char *msgclass, char *args)
 		hudinfo_notify(d, msgclass, "E", "Invalid arguments");
 		return;
 	}
-	
+
 	if( (cx < 0) || (cx > map->map_width) || (cy > map->map_height) || (cy < 0)) {
 		hudinfo_notify(d, msgclass, "E", "Out of range");
 		return;
@@ -1230,7 +1231,7 @@ static void hud_tactical(DESC * d, MECH * mech, char *msgclass, char *args)
 				*p = GetTerrain(map, x, y);
 				if(*p == ' ')
 					*p = '.';
-				*p++;
+				p++;
 			} else
 				*p++ = '?';
 
@@ -1250,7 +1251,7 @@ static char *hud_getmapflags(MAP * map)
 {
 	static char res[5];
 	char *p = res;
-	
+
 	if(map) {
 		if(map->flags & MAPFLAG_VACUUM)
 			*p++ = 'V';
@@ -1274,7 +1275,7 @@ static void hud_conditions(DESC * d, MECH * mech, char *msgclass, char *args)
 	MAP *map = getMap(mech->mapindex);
 	char res[200];
 	char lt;
-	
+
 	if(map)	{
 		switch (map->maplight) {
 		case 0:

--- a/btech/src/btech/map.c
+++ b/btech/src/btech/map.c
@@ -4,7 +4,7 @@
  *
  * Last modified: Fri Dec 11 00:59:48 1998 fingon
  *
- * Original authors: 
+ * Original authors:
  *   4.8.93- rdm created
  *   6.16.93- jb modified, added hex_struct
  * Since that modified by:
@@ -256,7 +256,7 @@ int map_checkmapfile(MAP * map, char *mapname)
 
 	if(!fp) {
 	        my_close_file(fp, &filemode);
-		return -1; // Bad map file 
+		return -1; // Bad map file
 	}
 
 	if(fscanf(fp, "%d %d\n", &width, &height) != 2 || height < 1 ||
@@ -371,7 +371,7 @@ int map_load(MAP * map, char *mapname)
 	map->map_width = width;
 	if(!MapNoBridgify(map))
 		make_bridges(map);
-	sprintf(map->mapname, mapname);
+	strcpy(map->mapname, mapname);
 	my_close_file(fp, &filemode);
 	return 0;
 }
@@ -399,7 +399,7 @@ void map_loadmap(dbref player, void *data, char *buffer)
 	case -3:
 		notify(player, "#-1 Map invalid - Height not loaded properly");
 		return;
-	case 1: 
+	case 1:
 		map_load(map, args[0]);
 		break;
 	default:
@@ -435,7 +435,7 @@ void map_savemap(dbref player, void *data, char *buffer)
 	DOCHECK(mech_parseattributes(buffer, args, 1) != 1,
 			"Invalid number of arguments!");
 	if(strlen(args[0]) >= MAP_NAME_SIZE)
-		args[MAP_NAME_SIZE] = 0;
+		args[0][MAP_NAME_SIZE] = 0;
 	notify_printf(player, "Saving %s", args[0]);
 	sprintf(openfile, "%s/", MAP_PATH);
 	strcat(openfile, args[0]);

--- a/btech/src/btech/map.conditions.c
+++ b/btech/src/btech/map.conditions.c
@@ -26,6 +26,7 @@
 #include "p.eject.h"
 #include "p.mech.sensor.h"
 #include "p.crit.h"
+#include "p.mech.ecm.h"
 
 void alter_conditions(MAP * map)
 {
@@ -246,7 +247,7 @@ void DestroyParts(MECH * attacker, MECH * wounded, int hitloc, int breach,
 						}
 						//check_stackpole(wounded, attacker);
 
-						if(mudconf.btech_stackpole && 
+						if(mudconf.btech_stackpole &&
 								(MechBoomStart(wounded) + MAX_BOOM_TIME) >= muxevent_tick &&
 								Roll() >= BOOM_BTH && (Started(wounded) || Starting(wounded))) {
 
@@ -255,14 +256,14 @@ void DestroyParts(MECH * attacker, MECH * wounded, int hitloc, int breach,
 									"releasing the fusion reaction!%cn");
 
 
-							reactor_explosion(wounded, attacker);	
+							reactor_explosion(wounded, attacker);
 						}
 
-						if((MechType(wounded) == CLASS_MECH) && 
-								(hitloc == LTORSO || hitloc == RTORSO) && (MechSpecials(wounded) && XL_TECH))
-						        DestroyMech(wounded, attacker, 1, 
-										(wounded == attacker) 
-										? KILL_TYPE_SELF_DESTRUCT 
+						if((MechType(wounded) == CLASS_MECH) &&
+								(hitloc == LTORSO || hitloc == RTORSO) && (MechSpecials(wounded) & XL_TECH))
+						        DestroyMech(wounded, attacker, 1,
+										(wounded == attacker)
+										? KILL_TYPE_SELF_DESTRUCT
 										: KILL_TYPE_XLENGINE);
 						else
 							DestroyMech(wounded, attacker, 1,
@@ -281,7 +282,7 @@ void DestroyParts(MECH * attacker, MECH * wounded, int hitloc, int breach,
 					}
 					break;
 				case TARGETING_COMPUTER:
-					if(!MechCritStatus(wounded) & TC_DESTROYED) {
+					if(!(MechCritStatus(wounded) & TC_DESTROYED)) {
 						if(attacker)
 							mech_notify(wounded, MECHALL,
 										"Your Targeting Computer is Destroyed");

--- a/btech/src/btech/map.dynamic.c
+++ b/btech/src/btech/map.dynamic.c
@@ -19,6 +19,7 @@
 #include <string.h>
 #include <errno.h>
 
+#include "glue.h"
 #include "create.h"
 #include "mech.h"
 #include "autopilot.h"

--- a/btech/src/btech/map.los.c
+++ b/btech/src/btech/map.los.c
@@ -1,7 +1,7 @@
 
 /*
  * $Id: map.los.c,v 1.1.1.1 2005/01/11 21:18:08 kstevens Exp $
- * 
+ *
  * Author: Thomas Wouters <thomas@xs4all.net>
  *
  * Copyright (c) 2002 Thomas Wouters
@@ -9,6 +9,7 @@
  *
  */
 
+#include "glue.h"
 #include "mech.h"
 #include "btmacros.h"
 #include "mech.sensor.h"
@@ -195,13 +196,13 @@ static int MechSeesTerrain(MECH * mech, int sn)
  * current hex and the seeing 'mech. If we end up with a hex between
  * minangle and blockangle, we need to check if the sensor can see through
  * that many woods.
- 
+
  * Blocking entirely, because of water- or EM-effects, is done by setting
  * the minangle and blockangle to 1000, a value high enough to block los to
  * all following hexes. To determine whether a sensors sees through a hex,
  * fake losflags are passed to the regular sensor functions... hacks, and
  * logic-duplication (the worst kind) but they work for now.
- 
+
  * This is all proof-of-concept, based on Cord Awtry's ideas for
  * 'underground' maps. This should all be rewritten, together with the
  * sensor code, to have one general 'tracelos' function, which calls

--- a/btech/src/btech/map.obj.c
+++ b/btech/src/btech/map.obj.c
@@ -162,8 +162,8 @@ void del_mapobj(MAP * map, mapobj * mapob, int type, int zap)
 			StopDec(mapob);
 	}
 	if(type == TYPE_BUILD) {
-		
-		if(tmap = getMap(mapob->obj)) {
+
+		if((tmap = getMap(mapob->obj))) {
 			del_mapobjst(tmap, TYPE_LEAVE);
 			tmap->onmap = 0;
 		}
@@ -500,7 +500,7 @@ static void fire_spreading_event(MUXEVENT * e)
 	new_fire_hex_y[3] = -1;
 	FindMyCoord(map, new_smoke_hex_x[0], new_smoke_hex_y[0], 0,
 				map->winddir, &new_smoke_hex_x[3], &new_smoke_hex_y[3]);
-	
+
 #define Spr(n,ch) \
   if(Roll() >= ch && Number(1,60) <= map->windspeed) \
     { \
@@ -748,7 +748,7 @@ void map_delobj(dbref player, void *data, char *buffer)
 	switch (mech_parseattributes(buffer, args, 3)) {
 	case 0:
 		notify(player,
-			   "Error: Invalid number of attributes to delobj command.");	
+			   "Error: Invalid number of attributes to delobj command.");
 		return;
 	case 1:
 		DOCHECK((tt = listmatch(map_types, args[0])) < 0, "Invalid type!");

--- a/btech/src/btech/mech.advanced.c
+++ b/btech/src/btech/mech.advanced.c
@@ -13,6 +13,7 @@
 #include <math.h>
 #include <sys/file.h>
 
+#include "glue.h"
 #include "mech.h"
 #include "mech.events.h"
 #include "coolmenu.h"
@@ -31,6 +32,7 @@
 #include "p.mech.enhanced.criticals.h"
 #include "p.mech.combat.misc.h"
 #include "mt19937ar.h"
+#include "p.map.conditions.h"
 
 #define SILLY_TOGGLE_MACRO(neededspecial,setstatus,msgon,msgoff,donthave) \
 if (MechSpecials(mech) & (neededspecial)) \
@@ -274,7 +276,7 @@ static int mech_toggle_mode_sub_func(MECH * mech, dbref player, int index,
 		DOCHECK0(!FindArtemisForWeapon(mech, section, critical),
 				 "You do not have an Artemis system for that weapon.");
 		}
-		
+
 
 	weaptype = Weapon2I(GetPartType(mech, section, critical));
 
@@ -300,7 +302,7 @@ static int mech_toggle_mode_sub_func(MECH * mech, dbref player, int index,
 									  critical) & ARTILLERY_MODES) &&
 					 !(GetPartAmmoMode(mech, section, critical) & temp_mode),
 					 "That weapon has already been set to fire special rounds!");
-           /* Fitz - Group RAC/INARC select: Handle clearing RAC and INARC modes first */ 
+           /* Fitz - Group RAC/INARC select: Handle clearing RAC and INARC modes first */
    		if ((temp_nspec == RAC) && !temp_mode) {
 			if (!(GetPartFireMode(mech, section, critical) & RAC_MODES)) {
 				mech_notify(mech, MECHALL, tprintf(temp_offmsg, index));
@@ -344,9 +346,9 @@ static int mech_toggle_mode_sub_func(MECH * mech, dbref player, int index,
 				GetPartAmmoMode(mech, section, critical) &= ~AMMO_MODES;
 				GetPartAmmoMode(mech, section, critical) |= temp_mode;
 			}
-	
+
 			mech_notify(mech, MECHALL, tprintf(temp_onmsg, index));
-	
+
 			return 0;
 			}
 		}if (temp_nspec != RAC) /* Keep RAC type weapons on this setting */
@@ -1783,13 +1785,13 @@ static struct mechpref_info {
 } mech_preferences[] = {
 	{ MECHPREF_PKILL, MECHPREF_FLAG_INVERTED, "MWSafety", "MechWarrior Safeties flipped"},
 	{ MECHPREF_SLWARN, 0			, "SLWarn", "The warning when lit by searchlight is now"},
-	{ MECHPREF_AUTOFALL, MECHPREF_FLAG_NEGATIVE, "AutoFall", "Suicidal jumps off cliffs toggled"}, 
-	{ MECHPREF_NOARMORWARN, MECHPREF_FLAG_INVERTED, "ArmorWarn", "Low-armor warnings turned"}, 
-	{ MECHPREF_NOAMMOWARN, MECHPREF_FLAG_INVERTED, "AmmoWarn", "Warning when running out of Ammunition switched"}, 
-	{ MECHPREF_AUTOCON_SD, MECHPREF_FLAG_NEGATIVE, "AutoconShutdown", "Autocon on shutdown units turned"}, 
-	{ MECHPREF_NOFRIENDLYFIRE, 0, "FFSafety", "Friendly Fire Safeties flipped"}, 
+	{ MECHPREF_AUTOFALL, MECHPREF_FLAG_NEGATIVE, "AutoFall", "Suicidal jumps off cliffs toggled"},
+	{ MECHPREF_NOARMORWARN, MECHPREF_FLAG_INVERTED, "ArmorWarn", "Low-armor warnings turned"},
+	{ MECHPREF_NOAMMOWARN, MECHPREF_FLAG_INVERTED, "AmmoWarn", "Warning when running out of Ammunition switched"},
+	{ MECHPREF_AUTOCON_SD, MECHPREF_FLAG_NEGATIVE, "AutoconShutdown", "Autocon on shutdown units turned"},
+	{ MECHPREF_NOFRIENDLYFIRE, 0, "FFSafety", "Friendly Fire Safeties flipped"},
 	{ MECHPREF_BTHDEBUG, MECHPREF_FLAG_NEGATIVE, "BTHDebug","BTH Debugging is now"}
-	
+
 	};
 #define NUM_MECHPREFERENCES (sizeof(mech_preferences) / sizeof(struct mechpref_info))
 

--- a/btech/src/btech/mech.ammodump.c
+++ b/btech/src/btech/mech.ammodump.c
@@ -9,6 +9,7 @@
  *  Copyright (c) 1998-2000 Thomas Wouters
  */
 
+#include "glue.h"
 #include "mech.h"
 #include "mech.events.h"
 #include "p.mech.ammodump.h"
@@ -258,7 +259,7 @@ int Dump_Decrease(MECH * mech, int loc, int pos, int *hm)
  * FASA rules state that if a mech takes a rear torso shot while dumping ammo,
  * all the dumping ammo explodes and goes to the armor of that location. That's
  * a bit harsh in RS as getting behind someone ain't that hard. So what we do is
- * if you're dumping ammo and take a rear torso shot, we, on a roll of 7 or less, 
+ * if you're dumping ammo and take a rear torso shot, we, on a roll of 7 or less,
  * call this BlowDumpingAmmo function. This function finds all the ammo you're dumping
  * and blows up ONE ROUND of one type, randomly. If you're dumping a lot and get hit
  * a few times (like from an LRM) you could get a bunch of little booms which

--- a/btech/src/btech/mech.bth.c
+++ b/btech/src/btech/mech.bth.c
@@ -15,6 +15,7 @@
 
 #include <math.h>
 
+#include "glue.h"
 #include "mech.h"
 #include "mech.events.h"
 #include "p.mech.bth.h"
@@ -321,7 +322,7 @@ int FindNormalBTH(MECH * mech,
 			BTHADD("Bsuitbonus", 1);
 
 		/* Let's see if we're targetting the head */
-		if(target && !IsMissile(weapindx) && MechAim(mech) == HEAD && 
+		if(target && !IsMissile(weapindx) && MechAim(mech) == HEAD &&
 			(MechType(target) == CLASS_MECH || MechType(target) == CLASS_MW)) {
 			if(Immobile(target))
 				BTHADD("HeadTarget", 7);
@@ -392,7 +393,7 @@ int FindNormalBTH(MECH * mech,
 /*		BTHADD("EvadingTarget", (FindPilotPiloting(target) >= 6 ? 1 :
 					 FindPilotPiloting(target) >= 4 ? 2 :
 					 FindPilotPiloting(target) >= 2 ? 3 : 4) +
-			(HasBoolAdvantage(MechPilot(target), "speed_demon") ? 1 : 0)); 
+			(HasBoolAdvantage(MechPilot(target), "speed_demon") ? 1 : 0));
 		} else if(MoveModeChange(target)) {
 			int i = MoveModeData(target);
 			if(i & MODE_SPRINT)
@@ -705,7 +706,7 @@ int AttackMovementMods(MECH * mech)
 // Lets just make this MechSpeed (the actual speed). Using DesiredSpeed is somewhat flawed
 
 	speed = MechSpeed(mech);
-	
+
 	if(mudconf.btech_fasaturn)
 		if(MechFacing(mech) != MechDesiredFacing(mech))
 			base++;

--- a/btech/src/btech/mech.c3.misc.c
+++ b/btech/src/btech/mech.c3.misc.c
@@ -8,6 +8,7 @@
  *  Copyright (c) 1998-2000 Thomas Wouters
  */
 
+#include "glue.h"
 #include "mech.h"
 #include "p.mech.c3.misc.h"
 #include "p.mech.c3.h"

--- a/btech/src/btech/mech.combat.c
+++ b/btech/src/btech/mech.combat.c
@@ -13,6 +13,7 @@
 #include <math.h>
 #include <sys/file.h>
 
+#include "glue.h"
 #include "mech.h"
 #include "map.h"
 #include "btmacros.h"
@@ -984,7 +985,7 @@ void FireWeapon(MECH * mech,
 		 */
 		SendAttacks(tprintf("#%i attacks #%i (weapon) (%i/%i)",
 							mech->mynum, target->mynum, baseToHit, roll));
-/*    
+/*
         SendXP(tprintf("#%i attacks #%i (weapon) (%i/%i)", mech->mynum,
             target->mynum, baseToHit, roll));
 */
@@ -1107,14 +1108,14 @@ void FireWeapon(MECH * mech,
 						MechWeapons[weapindx].damage, -1, 0, -1, 0,1);
 				decrement_ammunition(mech, weapindx, section, critical, ammoLoc, ammoCrit,
 						ammoLoc1, ammoCrit1, wGattlingShots);
-				
+
 
 			}
-			
+
 			return;
 		}
 	}
-	
+
 	/* Check for RFAC explosion/jams */
 	if(GetPartFireMode(mech, section, critical) & RFAC_MODE) {
 		if(roll == 2) {
@@ -1238,16 +1239,16 @@ void FireWeapon(MECH * mech,
 	 * Glancing_Blows = 0: NO Glancing. ROLL>=BTH=Normal
 	 * Glancing_Blows = 1: MaxTech Glancing. ROLL=BTH=Glance, ROLL>BTH=Normal
 	 * Glancing_Blows = 2: Exile Glancing. ROLL=BTH-1=Glance, ROLL>=BTH=Normal
-	 * We need to do a little handling here. The rest happens over it HitTarget 
+	 * We need to do a little handling here. The rest happens over it HitTarget
 	 */
 	RbaseToHit = baseToHit;
 	if(mudconf.btech_glancing_blows == 2)
 		RbaseToHit = baseToHit - 1; /* only time we modify it */
-	
+
 	if(!isarty) {
 /*		if(In_Character(mech->mynum)) {
 			if((roll < RbaseToHit) && (RbaseToHit < 13) && (RbaseToHit > 1))
-				rollstat.hitstats[RbaseToHit - 2][0]++; 
+				rollstat.hitstats[RbaseToHit - 2][0]++;
 			if((roll == RbaseToHit) && (mudconf.btech_glancing_blows) && (RbaseToHit < 13) && (RbaseToHit > 1))
 				rollstat.hitstats[RbaseToHit - 2][2]++;
 			if((roll >= RbaseToHit) && (!mudconf.btech_glancing_blows) && (RbaseToHit < 13) && (RbaseToHit > 1))
@@ -1259,7 +1260,7 @@ void FireWeapon(MECH * mech,
 			MechFireBroadcast(mech, ishex ? NULL : target, mapx, mapy,
 							  mech_map, &MechWeapons[weapindx].name[3],
 							  (roll >= RbaseToHit) && range_ok);
-		
+
 	}
 	/* Tell our target they were just shot at... */
 	if(target) {
@@ -1403,7 +1404,7 @@ void FireWeapon(MECH * mech,
 	/* Special for Heavy Gauss Rifles */
 	if((MechWeapons[weapindx].special & HVYGAUSS) &&
 	   (MechType(mech) == CLASS_MECH)) {
-		if(abs(MechSpeed(mech)) > 0.0) {
+		if(fabs(MechSpeed(mech)) > 0.0) {
 			mech_notify(mech, MECHALL,
 						"You realize that moving while firing this weapon may not be a good idea after all.");
 			if(MechTons(mech) <= 35)
@@ -1611,7 +1612,7 @@ void HitTarget(MECH * mech,
 			 * because we modified the bth in FireWeapon. Nothing to see here. move along
 			 */
 			MechLOSBroadcast(hitMech, "is nicked by a glancing blow!");
-			mech_notify(hitMech, MECHALL, 
+			mech_notify(hitMech, MECHALL,
 					"You are nicked by a glancing blow!");
 			wWeapDamage = (int ) (wWeapDamage +1) / 2 ;
 			if(wWeapDamage < 1 )

--- a/btech/src/btech/mech.combat.misc.c
+++ b/btech/src/btech/mech.combat.misc.c
@@ -8,6 +8,7 @@
 *  Copyright (c) 1998-2000 Thomas Wouters
 */
 
+#include "glue.h"
 #include "mech.h"
 #include "mech.events.h"
 #include "p.bsuit.h"
@@ -278,9 +279,9 @@ void DestroyMech(MECH * target, MECH * mech, int showboom, const char *reason)
 		return;
 	}
 	//global_kill_cheat = 1;
-	
+
 	// Destroy Contents Right Away
-	if(mudconf.btech_transported_unit_death) {	
+	if(mudconf.btech_transported_unit_death) {
 		SAFE_DOLIST(a,b,Contents(target->mynum))
 			if(IsMech(a) && In_Character(a)) {
 				ctarget = getMech(a);
@@ -295,7 +296,7 @@ void DestroyMech(MECH * target, MECH * mech, int showboom, const char *reason)
 	else
 		ChannelEmitKill(target, target, reason);
 	if(mech) {
-		
+
 			if(mech != target) {
 				mech_notify(mech, MECHALL, "You destroyed the target!");
 				MechLOSBroadcasti(target, mech, "has been destroyed by %s!");
@@ -331,7 +332,7 @@ void DestroyMech(MECH * target, MECH * mech, int showboom, const char *reason)
 			}
 		}
 	}
-	
+
 	/* shut it down */
 	if(mech) {
 		DestroyAndDump(target);

--- a/btech/src/btech/mech.combat.missile.c
+++ b/btech/src/btech/mech.combat.missile.c
@@ -24,6 +24,7 @@
 #include "p.mech.hitloc.h"
 #include "p.mech.los.h"
 #include "p.mech.utils.h"
+#include "p.mech.update.h"
 
 extern dbref pilot_override;
 
@@ -80,8 +81,8 @@ void Missile_Hit(MECH * mech,
 			sprintf(buf, "%s%s", "missile", orig_num_missiles > 1 ? "s" : "");
 		else if(ammoMode & LBX_MODE)
 			sprintf(buf, "%s%s", "pellet", orig_num_missiles > 1 ? "s" : "");
-		else if((fireMode && ULTRA_MODE) || (fireMode && RFAC_MODE) ||
-				(fireMode && RAC_MODES))
+		else if((fireMode & ULTRA_MODE) || (fireMode & RFAC_MODE) ||
+				(fireMode & RAC_MODES))
 			sprintf(buf, "%s%s", "slug", orig_num_missiles > 1 ? "s" : "");
 		else
 			sprintf(buf, "%s", "damage");
@@ -176,12 +177,12 @@ int MissileHitIndex(MECH * mech,
 		wRollInc += -4;
 	if(wRollInc)
 		hit_roll = hit_roll + wRollInc;
-	/* Glancing, per max tech, if its lower than 2 on the hit table, we hit with one missile. 
+	/* Glancing, per max tech, if its lower than 2 on the hit table, we hit with one missile.
 	 * return -1 so we can test for this elsewhere
 	 */
 	if(glance && (hit_roll < 0))
 		return -1;
-	
+
 	wFinalRoll = MAX(MIN(hit_roll, 10), 0);
 
 	return wFinalRoll;
@@ -480,7 +481,7 @@ void SwarmHitTarget(MECH * mech,
  */
 
 /****************************************
- * START: AMS related functions 
+ * START: AMS related functions
  ****************************************/
 int AMSMissiles(MECH * mech,
 				MECH * hitMech,
@@ -553,5 +554,5 @@ int LocateAMSDefenses(MECH * target,
 }
 
 /****************************************
- * END: AMS related functions 
+ * END: AMS related functions
  ****************************************/

--- a/btech/src/btech/mech.consistency.c
+++ b/btech/src/btech/mech.consistency.c
@@ -7,6 +7,7 @@
 
 #include "config.h"
 
+#include "glue.h"
 #include "mech.h"
 #include "coolmenu.h"
 #include "mycool.h"
@@ -199,27 +200,6 @@ int susp_factor(MECH * mech)
 		return 140;
 	}
 	return 0;
-}
-
-extern int round_to_halfton(int weight)
-{
-	int over = weight % 512;
-	if(!over)
-		return weight;
-	if(over < 2)
-		return weight - over;
-	return weight + (512 - over);
-}
-
-extern int round_to_quarterton(int weight)
-{
-	int over = weight % 256;
-	if(!over)
-		return weight;
-	if (over < 2)
-		return weight - over;
-	
-	return weight + (256 - over);
 }
 
 int crit_weight(MECH * mech, int t)
@@ -421,12 +401,13 @@ int mech_weight_sub_mech(dbref player, MECH * mech, int interactive)
 			"Engine (Light)" : "Engine", MechEngineSize(mech));
 	PLOC(CTORSO)
 		ADDENTRY(buf, engine_weight(mech));
-	PLOC(HEAD)
+	PLOC(HEAD) {
 		if(MechSpecials2(mech) & SMALLCOCKPIT_TECH) {
 			ADDENTRY("Cockpit (Small)", 2 * 1024);
 		} else {
 			ADDENTRY("Cockpit", 3 * 1024);
 		}
+	}
 	PLOC(CTORSO)
 		/* Store the base-line gyro weight */
 		gyro_calc = (MechEngineSize(mech) / 100.0);
@@ -469,7 +450,7 @@ int mech_weight_sub_mech(dbref player, MECH * mech, int interactive)
 			   MechSpecials(mech) & HARDA_TECH ? "Armor (Hardened)" :
 			   MechSpecials(mech) & FF_TECH ? "Armor (FF)" : "Armor", armor_o,
 			   round_to_halfton( armor * 1024 / (MechSpecials(mech) & HARDA_TECH ? 8 : 16) ));
-			   
+
 			  // ceil(armor /
 
 //					(8. * (MechSpecials(mech) & HARDA_TECH ? 2 : 1))) * 512);

--- a/btech/src/btech/mech.contacts.c
+++ b/btech/src/btech/mech.contacts.c
@@ -264,7 +264,7 @@ void mech_contacts(dbref player, void *data, char *buffer)
 	int mechfound;
 	char weaponarc;
 	char *mech_name;
-	char see_what;
+	unsigned char see_what;
 	char *str;
 	char move_type[30];
 	char cStatus1, cStatus2, cStatus3, cStatus4, cStatus5;

--- a/btech/src/btech/mech.damage.c
+++ b/btech/src/btech/mech.damage.c
@@ -28,7 +28,9 @@
 #include "p.mech.ood.h"
 #include "p.mech.utils.h"
 #include "p.mech.pickup.h"
+#include "p.mech.update.h"
 #include "p.pcombat.h"
+#include "p.mechrep.h"
 
 static char *MyColorStrings[] = {
 	"", "%ch%cg", "%ch%cy", "%cr"
@@ -130,7 +132,7 @@ int cause_armordamage(MECH * wounded,
 
 		/* Silly stuff */
 		/*
-		   SetSectArmor(wounded, hitloc, MAX(0, intDamage =  
+		   SetSectArmor(wounded, hitloc, MAX(0, intDamage =
 		   GetSectArmor(wounded, hitloc) - damage));
 		   intDamage = abs(intDamage);
 		 */
@@ -378,7 +380,7 @@ void DamageMech(MECH * wounded,
 /* Rare case something passes through. We're in WEAPONS_HOLD. Don't even allow it */
 	if( MechStatus2(attacker) & WEAPONS_HOLD) {
 		if(wounded != attacker)
-			mech_notify(attacker, MECHALL, 
+			mech_notify(attacker, MECHALL,
 						"You are currently in weapons hold!");
 	}
 
@@ -575,7 +577,7 @@ void DamageMech(MECH * wounded,
 				damage + (intDamage < 0 ? 0 : intDamage));
 
 	/* Only count initial damage. Transfer is just gonna do that, transfer, not damage again */
-	if (!was_transfer) {	
+	if (!was_transfer) {
 		if(attacker != wounded)
 			MechDamageInflicted(attacker) = MechDamageInflicted(attacker) + damage + (intDamage < 0 ? 0 : intDamage);
 		MechDamageTaken(wounded) = MechDamageTaken(wounded) + damage + (intDamage < 0 ? 0 : intDamage);
@@ -591,7 +593,7 @@ void DamageMech(MECH * wounded,
 						"%%cgDamage transfer.. %s%%c", notificationBuff);
 	}
 	if(MechType(wounded) == CLASS_MW && !was_transfer)
-		if(damage > 0) 
+		if(damage > 0)
 			if(!(damage =
 				 armor_effect(wounded, cause, hitloc, damage, intDamage)))
 				return;
@@ -605,7 +607,7 @@ void DamageMech(MECH * wounded,
 		  // So now that stagger isn't completely retarded, here's how it works
 		  // you take damage and every point of damage gets added to a linked list in the
 		  // mech struct's RS object (mech->rd). This damage is a linked list, and each node
-		  // contains the time of the damage, the amount, the attacker's dbref and a link to 
+		  // contains the time of the damage, the amount, the attacker's dbref and a link to
 		  // the next damage. if the node->next is NULL, you're at the end of the list.
 
 
@@ -794,7 +796,7 @@ void DamageMech(MECH * wounded,
 	if(wWeapIndx > 0) {
 		if(strstr(MechWeapons[wWeapIndx].name, "IS.PlasmaRifle")) {
 			if(MechType(wounded) == CLASS_MECH)
-				Plasma_Hit(attacker, wounded, LOS);	
+				Plasma_Hit(attacker, wounded, LOS);
 		}
 	}
 	/* Check to see if we blow up ammo that's dumping. */
@@ -928,7 +930,7 @@ void DestroySection(MECH * wounded, MECH * attacker, int LOS, int hitloc)
 				   && (MechIsQuad(wounded))));
 	dbref wounded_pilot = MechPilot(wounded);
 	MECH *ttarget;
-	
+
 	/* Prevent the rare occurance of a section getting destroyed twice */
 	if(SectIsDestroyed(wounded, hitloc)) {
 		fprintf(stderr, "Double-desting section %d on mech #%ld\n",
@@ -954,7 +956,7 @@ void DestroySection(MECH * wounded, MECH * attacker, int LOS, int hitloc)
 
 	/* uncycle the section <in the case of an arm/leg that was kicking getting blown */
 	SetRecycleLimb(wounded, hitloc, 0);
-	
+
 	/* drop off what we were carrying, since we really can't pick it up with one arm */
 	if((hitloc == RARM || hitloc == LARM)) {
 		if(MechCarrying(wounded) > 0) {
@@ -964,7 +966,7 @@ void DestroySection(MECH * wounded, MECH * attacker, int LOS, int hitloc)
 			}
 		}
 	}
-		
+
 	/* Tell the attacker about it... */
 	if(attacker) {
 		ArmorStringFromIndex(hitloc, locname, MechType(wounded),
@@ -1031,15 +1033,17 @@ void DestroySection(MECH * wounded, MECH * attacker, int LOS, int hitloc)
 		else if(hitloc == RTORSO)
 			DestroySection(wounded, attacker, LOS, RARM);
 		else if(hitloc == CTORSO || hitloc == HEAD) {
-			if(!Destroyed(wounded))
-				if(hitloc == HEAD)
+			if(!Destroyed(wounded)) {
+				if(hitloc == HEAD) {
 					if(MechAim(attacker) == HEAD) {
 						DestroyMech(wounded, attacker, 1, KILL_TYPE_HEAD_TARGET);
 					} else {
 						DestroyMech(wounded, attacker, 1, KILL_TYPE_BEHEADED);
 					}
-				else
+				} else {
 					DestroyMech(wounded, attacker, 1, KILL_TYPE_NORMAL);
+				}
+			}
 			/* If it's the head or a MW's CT, kill the contents if IC */
 			if(hitloc == HEAD || ((MechType(wounded) == CLASS_MW) &&
 								  (hitloc == CTORSO))) {
@@ -1210,7 +1214,7 @@ void mech_damage_section(dbref player, MECH * mech, char *buffer)
 		invalid_section(player, mech);
 		return;
 	}
-	
+
 	DOCHECK(Readnum(damage, args[1]), "Invalid damage (Arg 2) amount! (Must be a number!)");
 	DOCHECK(Readnum(isrear, args[2]), "Isrear value (Arg 3) Invalid! (1 or 0)");
 	DOCHECK(Readnum(iscritical, args[3]), "Iscritical value (Arg 4) Invalid! (1 or 0)");

--- a/btech/src/btech/mech.events.c
+++ b/btech/src/btech/mech.events.c
@@ -9,6 +9,8 @@
  */
 
 #include <math.h>
+
+#include "glue.h"
 #include "mech.events.h"
 #include "mech.notify.h"
 #include "p.aero.move.h"
@@ -23,7 +25,7 @@
 #undef WEAPON_RECYCLE_DEBUG
 
 void mech_heartbeat(MECH *mech) {
-    UpdateRecycling(mech); 
+    UpdateRecycling(mech);
     if(mudconf.btech_newstagger >= 1 && MechType(mech) == CLASS_MECH) {
       // no sense checking if a fallen mech will fall down again, and let's not let jumping mechs stagger.
       if(!Fallen(mech) && !Jumping(mech)) {
@@ -31,7 +33,7 @@ void mech_heartbeat(MECH *mech) {
       }
       ClearStaggerDamage(mech);
     }
-    // Aeros need to check fuel while sitting and hovering 
+    // Aeros need to check fuel while sitting and hovering
     if(MechType(mech) == CLASS_AERO || MechType(mech) == CLASS_VTOL) {
     	if(!Landed(mech) && (fabs(MechSpeed(mech)) == 0) && (fabs(MechVerticalSpeed(mech)) == 0) )
  		FuelCheck(mech);
@@ -40,7 +42,7 @@ void mech_heartbeat(MECH *mech) {
     return;
 }
 
-void mech_staggercheck_heartbeat(MECH * mech) 
+void mech_staggercheck_heartbeat(MECH * mech)
 {
   time_t now = mudstate.now;
   int curStaggerDamage = 0;
@@ -61,8 +63,8 @@ void mech_staggercheck_heartbeat(MECH * mech)
       return;
     else {
       staggerLevel = curStaggerDamage / 20;
-      
-      // Dont need to remove stagger anymore, it clears on fall, 
+
+      // Dont need to remove stagger anymore, it clears on fall,
       // unless we're using mudconf.btech_newstagger = 2
       if(mudconf.btech_newstagger == 2)
 	RemoveStaggerDamage(mech,staggerLevel);
@@ -116,7 +118,7 @@ int calcNewStaggerBTHMod(MECH * mech, int staggerLevel)
     bthMod = 999;
   } else {
     bthMod = staggerLevel - 1;
- 
+
     if(MechTons(mech) <= 35)
       tonnageMod = 1;
     else if(MechTons(mech) <= 55)
@@ -130,7 +132,7 @@ int calcNewStaggerBTHMod(MECH * mech, int staggerLevel)
     if(mudconf.btech_newstaggertons)
       bthMod += tonnageMod;
   }
- 
+
   return bthMod;
 }
 
@@ -168,14 +170,14 @@ void mech_fall_event(MUXEVENT * e)
 	else
 		fallspeed += FALL_ACCEL;
 	MarkForLOSUpdate(mech);
-	if(MechsElevation(mech) > abs(fallspeed)) {
-		MechZ(mech) -= abs(fallspeed);
+	if(MechsElevation(mech) > labs(fallspeed)) {
+		MechZ(mech) -= labs(fallspeed);
 		MechFZ(mech) = MechZ(mech) * ZSCALE;
 		MECHEVENT(mech, EVENT_FALL, mech_fall_event, FALL_TICK, fallspeed);
 		return;
 	}
 	/* Time to hit da ground */
-	fallen_elev = factoral(abs(fallspeed));
+	fallen_elev = factoral(labs(fallspeed));
 	mech_notify(mech, MECHALL, "You hit the ground!");
 	MechLOSBroadcast(mech, "hits the ground!");
 	MechFalls(mech, fallen_elev, 0);
@@ -395,7 +397,7 @@ void aero_move_event(MUXEVENT * e)
 		/* Returns 1 only if we
 		   1) Ran out of fuel, and
 		   2) Were VTOL, and
-		   3) Crashed 
+		   3) Crashed
 		 */
 		if(FuelCheck(mech))
 			return;

--- a/btech/src/btech/mech.hitloc.c
+++ b/btech/src/btech/mech.hitloc.c
@@ -7,6 +7,7 @@
  *       All rights reserved
  */
 
+#include "glue.h"
 #include "mech.h"
 #include "mech.events.h"
 #include "p.mech.utils.h"
@@ -31,12 +32,12 @@ int FindPunchLocation(MECH *target, int hitGroup) {
                 switch (roll) {
                     case 1:
                     case 2:
-                        return LTORSO; 
+                        return LTORSO;
                     case 3:
                         return CTORSO;
                     case 4:
                         /* Front Left Leg */
-                        return LARM; 
+                        return LARM;
                     case 5:
                         /* Rear Left Leg */
                         return LLEG;
@@ -281,7 +282,7 @@ int ModifyHeadHit(int hitGroup, MECH *mech) {
 
         	MECHEVENT(mech, EVENT_CREWSTUN, mech_crewstun_event, MECHSTUN_TICK, 0);
 	    }
-	 
+
     return newloc;
 }
 
@@ -494,7 +495,7 @@ int FindFasaHitLocation(MECH * mech, int hitGroup, int *iscritical,
 		case BACK:
 			switch (roll) {
 			case 2:
-            SendTAC(tprintf("%d's luck sucks. It got TACed. We're in FindFasaHitLocation()",mech->mynum));			            
+            SendTAC(tprintf("%d's luck sucks. It got TACed. We're in FindFasaHitLocation()",mech->mynum));
 				*iscritical = 1;
 				return CTORSO;
 			case 3:
@@ -2184,7 +2185,7 @@ int FindHitLocation(MECH * mech, int hitGroup, int *iscritical, int *isrear)
 		if(MechSpecials(mech) & CRITPROOF_TECH)
 			return FindHitLocation_CritProof(mech, hitGroup, iscritical,
 											 isrear);
-		else if(mudconf.btech_fasacrit) 
+		else if(mudconf.btech_fasacrit)
    			return FindFasaHitLocation(mech, hitGroup, iscritical, isrear);
 		break;
 	}

--- a/btech/src/btech/mech.ice.c
+++ b/btech/src/btech/mech.ice.c
@@ -14,6 +14,7 @@
 #include "p.mech.utils.h"
 #include "p.mech.pickup.h"
 #include "p.mech.tag.h"
+#include "p.mech.combat.misc.h"
 
 #define TMP_TERR '1'
 

--- a/btech/src/btech/mech.los.c
+++ b/btech/src/btech/mech.los.c
@@ -18,6 +18,7 @@
 #include <math.h>
 #include <sys/file.h>
 
+#include "glue.h"
 #include "mech.h"
 #include "p.map.obj.h"
 #include "p.mech.sensor.h"

--- a/btech/src/btech/mech.maps.c
+++ b/btech/src/btech/mech.maps.c
@@ -15,6 +15,7 @@
 #include <math.h>
 #include <sys/file.h>
 
+#include "glue.h"
 #include "mech.h"
 #include "mine.h"
 #include "create.h"
@@ -269,7 +270,7 @@ void mech_navigate(dbref player, void *data, char *buffer)
 
 /* INDENT OFF */
 
-/* 
+/*
    0
    ___________                                     /``\][/""\][/""\
    /           \          HEX Location: 254, 122    \`1/``\""/``\""/
@@ -566,7 +567,7 @@ static void show_lrs_map(dbref player, MECH * mech, MAP * map, int x,
 					mechs[last_mech++] = oMech;
 			}
 		}
-		for(i = 0; i < (last_mech - 1); i++)	/* Bubble-sort the list 
+		for(i = 0; i < (last_mech - 1); i++)	/* Bubble-sort the list
 												 *  to y/x order */
 			for(loop = (i + 1); loop < last_mech; loop++) {
 				if(MechY(mechs[i]) > MechY(mechs[loop])) {
@@ -789,7 +790,7 @@ static void sketch_tac_map(char *buf, MAP * map, MECH * mech, int sx,
 	sketch_tac_row(pos, left_offset, hexrow[oddcol1], mapcols);
 
 	/*
-	 * Now draw the terrain and elevation. 
+	 * Now draw the terrain and elevation.
 	 */
 	pos = buf + top_offset * dispcols + left_offset;
 	wx = MIN(wx, map->map_width - sx);
@@ -956,7 +957,7 @@ static void sketch_tac_mechs(char *buf, MAP * map, MECH * player_mech,
 		}
 
 		/*
-		 * Check to see if the 'mech is on the tac map and 
+		 * Check to see if the 'mech is on the tac map and
 		 * that its in LOS of the player's 'mech.
 		 */
 		x = MechX(mech) - sx;
@@ -1067,7 +1068,7 @@ static void sketch_tac_cliffs(char *buf, MAP * map, int sx, int sy, int wx,
 			char c;
 
 			/*
-			 * Copy the elevation up to the top of the hex 
+			 * Copy the elevation up to the top of the hex
 			 * so we can draw a bottom hex edge on every hex.
 			 */
 			c = base[dispcols + 1];
@@ -1080,7 +1081,7 @@ static void sketch_tac_cliffs(char *buf, MAP * map, int sx, int sy, int wx,
 
 			/*
 			 * For each hex on the map check to see if each
-			 * of it's 240, 180, and 120 hex sides is a cliff. 
+			 * of it's 240, 180, and 120 hex sides is a cliff.
 			 * Don't check for cliffs between hexes that are on
 			 * the tac map and those that are off of it.
 			 */
@@ -1189,8 +1190,8 @@ sketch_tac_mines(char *buf, MAP *map, MECH *mech, int sx, int sy, int wx,
                                InLineOfSight_NB(mech,NULL, tx,ty,hex_range) ) {
                          /*     base[dispcols]=(o->datas/10) + '0'; */
                          /*     base[dispcols+1]=(o->datas%10) + '0'; */
-                              base[dispcols]='<'; 
-                              base[dispcols+1]='>'; 
+                              base[dispcols]='<';
+                              base[dispcols+1]='>';
 
                          }
                         }
@@ -1362,7 +1363,7 @@ static char **colourize_tac_map(char const *sketch, int dispcols,
  * freed with KillText().
  *
  * player   = dbref of player wanting map (mostly irrelevant)
- * mech     = mech player's in (or NULL, if on map) 
+ * mech     = mech player's in (or NULL, if on map)
  * map      = map obj itself
  * cx       = middle of the map (x)
  * cy       = middle of the map (y)
@@ -1415,7 +1416,7 @@ char **MakeMapText(dbref player, MECH * mech, MAP * map, int cx, int cy,
 	}
 
 	/*
-	 * Figure out the extent of the tac map to draw.  
+	 * Figure out the extent of the tac map to draw.
 	 */
 	wx = MIN(MAX_WIDTH, wx);
 	wy = MIN(MAX_HEIGHT, wy);
@@ -1528,7 +1529,7 @@ char **MakeMapText(dbref player, MECH * mech, MAP * map, int cx, int cy,
 						top_offset, left_offset, 2, docolour);
         } else if (labels & 128) {
                 if (mech != NULL) {
-                       sketch_tac_ownmech(sketch_buf, map, mech, sx, sy, wx, wy, 
+                       sketch_tac_ownmech(sketch_buf, map, mech, sx, sy, wx, wy,
 						dispcols, top_offset, left_offset);
                        sketch_tac_mines(sketch_buf, map, mech, sx, sy, wx, wy,
 						dispcols, top_offset, left_offset);
@@ -1551,7 +1552,7 @@ char **MakeMapText(dbref player, MECH * mech, MAP * map, int cx, int cy,
 		 */
 		if(oddcol1) {
 			/*
-			 * Don't need the last line in this case. 
+			 * Don't need the last line in this case.
 			 */
 			disprows--;
 		}
@@ -1598,7 +1599,7 @@ char **MakeMapText(dbref player, MECH * mech, MAP * map, int cx, int cy,
 	return lines;
 }
 
-/* Draws the map for the player when they use the 
+/* Draws the map for the player when they use the
  * TACTICAL [C | T | L] [<BEARING> <RANGE> | <TARGET-ID>]
  * command inside a unit */
 void mech_tacmap(dbref player, void *data, char *buffer)
@@ -1631,7 +1632,7 @@ void mech_tacmap(dbref player, void *data, char *buffer)
 							   mudconf.btech_mw_losmap))
 		dohexlos = 1;
 
-	/* Check to see which type of tactical to display 
+	/* Check to see which type of tactical to display
 	 * if they specified a particular one */
 	if(argc > 0 && isalpha((unsigned char) args[0][0])
 	   && args[0][1] == '\0') {
@@ -1845,7 +1846,7 @@ void mech_enterbase(dbref player, void *data, char *buffer)
 
 		/* Trigger FAIL & AFAIL */
 		memset(fail_mesg, 0, sizeof(fail_mesg));
-		snprintf(fail_mesg, LBUF_SIZE, "The hangar is locked.");
+		snprintf(fail_mesg, SBUF_SIZE, "The hangar is locked.");
 
 		did_it(player, newmap->mynum, A_FAIL, fail_mesg, 0, NULL, A_AFAIL,
 			   (char **) NULL, 0);

--- a/btech/src/btech/mech.move.c
+++ b/btech/src/btech/mech.move.c
@@ -15,6 +15,7 @@
 #include <math.h>
 #include <sys/file.h>
 
+#include "glue.h"
 #include "mech.h"
 #include "mech.events.h"
 #include "p.mech.events.h"
@@ -290,7 +291,7 @@ void mech_eta(dbref player, void *data, char *buffer)
 					"Range to hex (%d,%d) is %.1f.  ETA: Never, mech not moving.",
 					eta_x, eta_y, range);
 	else {
-		etamin = abs(range / (MechSpeed(mech) / KPH_PER_MP));
+		etamin = (int)fabs(range / (MechSpeed(mech) / KPH_PER_MP));
 		etahr = etamin / 60;
 		etamin = etamin % 60;
 		mech_printf(mech, MECHALL,
@@ -348,11 +349,11 @@ float MechCargoMaxSpeed(MECH * mech, float mspeed)
 											 (MechStatus2(mech) & SPRINTING
 											  ? 0.5 : 0.0));
 
-		if((MechSpecials(mech) & TRIPLE_MYOMER_TECH) && (MechHeat(mech) >= 9.)) { 
+		if((MechSpecials(mech) & TRIPLE_MYOMER_TECH) && (MechHeat(mech) >= 9.)) {
 			if((MechStatus2(mech) & SPRINTING)) {
 				if(mudconf.btech_tsm_sprint_bonus)
 					mspeed = ceil((rint((mspeed / 1.5) / MP1) + 1) * 1.5) * MP1;
-				
+
 			} else {
 				mspeed = ceil((rint((mspeed / 1.5) / MP1) + 1) * 1.5) * MP1;
 			}
@@ -380,7 +381,7 @@ float MechCargoMaxSpeed(MECH * mech, float mspeed)
 				if(MechSpecials(mech) & SALVAGE_TECH)
 					lugged = lugged / 2;
 				if((MechSpecials(mech) & TRIPLE_MYOMER_TECH) &&
-				   (MechHeat(mech) >= 9.) && mudconf.btech_tsm_tow_bonus) 
+				   (MechHeat(mech) >= 9.) && mudconf.btech_tsm_tow_bonus)
 					lugged = lugged / 2;
 
 				if(MechSpecials2(mech) & CARRIER_TECH)
@@ -580,7 +581,7 @@ void mech_stand(dbref player, void *data, char *buffer)
 			standcarefulmod = -2;
 		} else {
 			notify_printf(player, "Unknown argument! use 'stand check'%s",
-				   mudconf.btech_standcareful ? ", 'stand careful' or 'stand anyway'" 
+				   mudconf.btech_standcareful ? ", 'stand careful' or 'stand anyway'"
 				   			      : " or 'stand anyway'");
 			for(i = 0; i < 2; i++) {
 				if(args[i])
@@ -1056,7 +1057,7 @@ void mech_thrash(dbref player, void *data, char *buffer)
 #endif /* REALWEIGHT_DAMAGE */
 
 	/* Rules say tonnage/3, not tonnage/3 * limbs  Page 151, Total Warfare*/
-	
+
 
 	mech_notify(mech, MECHALL,
 				"You start to flail your arms and legs like a wild man!");
@@ -1355,7 +1356,7 @@ void mech_sprint(dbref player, void *data, char *buffer)
 					MOVE_QUAD ? 0 : SectIsDestroyed(mech, RLEG)
 					|| SectIsDestroyed(mech, LLEG)),
 				"That's kind of hard while limping.");
-	
+
 	DOCHECK(MechChargeTarget(mech) > 0, "You are currently charging a target and unable to start sprinting!");
 
 	d |= MODE_SPRINT | ((MechStatus2(mech) & SPRINTING) ? MODE_OFF : MODE_ON);
@@ -1386,7 +1387,7 @@ void mech_evade(dbref player, void *data, char *buffer)
 
 	cch(MECH_USUALO);
 	DOCHECK(Fortified(mech), "Your fortified state prevents you from moving.");
-	DOCHECK(OODing(mech), "While falling out of the sky?");	
+	DOCHECK(OODing(mech), "While falling out of the sky?");
 	DOCHECK(MechMove(mech) == MOVE_NONE,
 			"This piece of equipment is stationary!");
 	DOCHECK(Standing(mech), "You are currently standing up and cannot move.");
@@ -1409,7 +1410,7 @@ void mech_evade(dbref player, void *data, char *buffer)
 			"You cannot perform multiple movement modes!");
 	DOCHECK(MechSwarmTarget(mech) > 0, "You cannot evade while mounted!");
 	DOCHECK(MechChargeTarget(mech) > 0, "You cannot evade while charging!");
-	
+
 	if(MechType(mech) == CLASS_MECH)
 		DOCHECK(SectIsDestroyed(mech, RLEG) || SectIsDestroyed(mech, LLEG)
 				|| (MechMove(mech) !=
@@ -1445,7 +1446,7 @@ void mech_dodge(dbref player, void *data, char *buffer)
 
 	cch(MECH_USUALO);
 	DOCHECK(Fortified(mech), "Your fortified state prevents you from moving.");
-	DOCHECK(OODing(mech), "While falling out of the sky?");	
+	DOCHECK(OODing(mech), "While falling out of the sky?");
 	DOCHECK(MechMove(mech) == MOVE_NONE,
 			"This piece of equipment is stationary!");
 	DOCHECK(Standing(mech), "You are currently standing up and cannot move.");
@@ -1818,7 +1819,7 @@ void MechFalls(MECH * mech, int levels, int seemsg)
 
 	/* damage pilot */
 	MechCocoon(mech) = 0;
-	
+
 /* Rule Reference: BMR Revised, Page 16 ( Fall = Bruise if Pilot roll fails) */
 /* Rule Reference: Total Warfare, Page 41 ( Fall = Bruise if Pilot roll fails) */
 

--- a/btech/src/btech/mech.notify.c
+++ b/btech/src/btech/mech.notify.c
@@ -13,6 +13,7 @@
 #include <math.h>
 #include <sys/file.h>
 
+#include "glue.h"
 #include "mech.h"
 #include "mech.events.h"
 #include "autopilot.h"
@@ -660,8 +661,6 @@ static char *ccode(MECH * m, int i, int obs, int team)
 			if(team == obs_team_color[ii].team)
 				sprintf(buf, "%s", obs_team_color[ii].ccode);
 		}
-		if(buf == NULL)
-			sprintf(buf, "%s", obs_team_color[0].ccode);
 	}
 	return buf;
 }
@@ -1054,7 +1053,7 @@ void nonrecursive_commlink(int i)
 		}
 		if(iter_c++ == 100000) {
 /* Lets not spam MechErrors with this.. */
-/* 
+/*
 			SendError(tprintf
 					  ("#%d: Infinite loop in relay code (?) ; using backup recursive code (num_mechs:%d, maxdepth:%d, nowdepth:%d)",
 					   comm_mech[0]->mynum, comm_num_to_conn, maxdepth, dep));

--- a/btech/src/btech/mech.partnames.c
+++ b/btech/src/btech/mech.partnames.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "glue.h"
 #include "mech.h"
 #include "htab.h"
 #include "create.h"
@@ -17,7 +18,7 @@
 
 void list_hashstat(dbref player, const char *tab_name, HASHTAB * htab);
 
-/* Main idea: 
+/* Main idea:
    Keep 2 sorted tables, one of shortform -> index
    longform  -> index
    vlongform -> index

--- a/btech/src/btech/mech.physical.c
+++ b/btech/src/btech/mech.physical.c
@@ -14,6 +14,7 @@
 #include <math.h>
 #include <sys/file.h>
 
+#include "glue.h"
 #include "mech.h"
 #include "map.h"
 #include "mech.events.h"
@@ -28,6 +29,7 @@
 #include "p.btechstats.h"
 #include "p.template.h"
 #include "p.mech.bth.h"
+#include "p.mech.update.h"
 
 // Only allows arm physical attacks for CLASS_MECH.
 #define ARM_PHYS_CHECK(a) \
@@ -355,7 +357,7 @@ void mech_punch(dbref player, void *data, char *buffer)
 
 	// If the directive is true, use the pilot's piloting skill. If not, we
 	// use a constant BTH of 4.
-	if(mudconf.btech_phys_use_pskill) 
+	if(mudconf.btech_phys_use_pskill)
 	 	rtohit = ltohit = FindPilotPiloting(mech);
 
 
@@ -370,7 +372,7 @@ void mech_punch(dbref player, void *data, char *buffer)
 		return;
 
 	// For each arm we're using, check to make sure it's good to punch with
-	// and carry out the roll if it is. 
+	// and carry out the roll if it is.
 	if(punching & P_LEFT) {
 		if(punch_checkArm(mech, LARM))
 			PhysicalAttack(mech, 10, ltohit, PA_PUNCH, argc, args,
@@ -438,7 +440,7 @@ void mech_club(dbref player, void *data, char *buffer)
 			  "You have weapons recycling on your arms.");
 
 	PhysicalAttack(mech, 5,
-				   (mudconf.btech_phys_use_pskill ? FindPilotPiloting(mech) - 1 
+				   (mudconf.btech_phys_use_pskill ? FindPilotPiloting(mech) - 1
                     : 4), PA_CLUB, argc,
 				   args, mech_map, RARM);
 }								// end mech_club()
@@ -466,7 +468,7 @@ int axe_checkArm(MECH * mech, int arm)
 					arm_used);
 		return 0;
 	}
-	// Fall through to success.    
+	// Fall through to success.
 	return 1;
 }								// end axe_checkArm()
 
@@ -534,7 +536,7 @@ int saw_checkArm(MECH * mech, int arm)
 					arm_used);
 		return 0;
 	}
-	// Fall through to success.    
+	// Fall through to success.
 	return 1;
 }								// end saw_checkArm()
 
@@ -606,7 +608,7 @@ void mech_claw(dbref player, void *data, char *buffer)
 
 	// If the directive is true, use the pilot's piloting skill. If not, we
 	// use a constant BTH of 4.
-	if(mudconf.btech_phys_use_pskill) 
+	if(mudconf.btech_phys_use_pskill)
 	 	rtohit = ltohit = FindPilotPiloting(mech);
 
 
@@ -621,7 +623,7 @@ void mech_claw(dbref player, void *data, char *buffer)
 		return;
 
 	// For each arm we're using, check to make sure it's good to punch with
-	// and carry out the roll if it is. 
+	// and carry out the roll if it is.
 	if(using & P_LEFT) {
 			PhysicalAttack(mech, 7, ltohit, PA_CLAW, argc, args,
 						   mech_map, LARM);
@@ -631,10 +633,10 @@ void mech_claw(dbref player, void *data, char *buffer)
 			PhysicalAttack(mech, 7, rtohit, PA_CLAW, argc, args,
 						   mech_map, RARM);
 	}
- 
+
         // We don't have a claw
 	DOCHECKMA(!using, "You do not have any claws! Try punching/clubbing instead!");
-		
+
 }								// end mech_claw()
 
 
@@ -1008,7 +1010,7 @@ void PhysicalAttack(MECH * mech, int damageweight, int baseToHit,
 	char location[20];
 	int ts = 0, iwa;
 	int RbaseToHit, glance = 0;
-	
+
 
 	/*
 	 * Common Checks
@@ -1025,9 +1027,9 @@ void PhysicalAttack(MECH * mech, int damageweight, int baseToHit,
 			return;
 	}
 
-    /* BTH Adjustments for crits to limbs - seperate one for 
+    /* BTH Adjustments for crits to limbs - seperate one for
      * club because it checks for both limbs */
-    if ((AttackType == PA_PUNCH) || (AttackType == PA_KICK) || 
+    if ((AttackType == PA_PUNCH) || (AttackType == PA_KICK) ||
             (AttackType == PA_AXE) || (AttackType == PA_SWORD) ||
 	    (AttackType == PA_CLAW) ||
             (AttackType == PA_MACE) || (AttackType == PA_SAW)) {
@@ -1159,11 +1161,11 @@ void PhysicalAttack(MECH * mech, int damageweight, int baseToHit,
 
 	DOCHECKMA(MapNoPhysicals(mech_map),"You cannot perform physical attacks here!");
 
-    DOCHECKMA(MechTeam(target) == MechTeam(mech) && 
+    DOCHECKMA(MechTeam(target) == MechTeam(mech) &&
             MechNoFriendlyFire(mech),
             "You can't attack a teammate with FFSafeties on!");
 
-    DOCHECKMA(MechTeam(target) == MechTeam(mech) && 
+    DOCHECKMA(MechTeam(target) == MechTeam(mech) &&
             MapNoFriendlyFire(mech_map),
             "Friendly Fire? I don't think so...");
 
@@ -1189,7 +1191,7 @@ void PhysicalAttack(MECH * mech, int damageweight, int baseToHit,
 	DOCHECKMA(AttackType == PA_TRIP && (Fallen(target) || Standing(target)),
 			  "Your target is already down!");
 
-	// We're attacking a ground/naval unit.    
+	// We're attacking a ground/naval unit.
 	if(MechMove(target) != MOVE_VTOL && MechMove(target) != MOVE_FLY) {
 
 		if((AttackType != PA_KICK && AttackType != PA_TRIP) &&
@@ -1201,8 +1203,8 @@ void PhysicalAttack(MECH * mech, int damageweight, int baseToHit,
 				isTooLow = 1;
 
             /* Target is to low to punch */
-            if ((MechType(target) == CLASS_MECH) && 
-                    (MechZ(mech) > MechZ(target)) && 
+            if ((MechType(target) == CLASS_MECH) &&
+                    (MechZ(mech) > MechZ(target)) &&
                     (AttackType == PA_PUNCH)) {
                 isTooLow = 1;
             }
@@ -1273,7 +1275,7 @@ void PhysicalAttack(MECH * mech, int damageweight, int baseToHit,
 	/* Check weapon arc! */
 	/* Theoretically, physical attacks occur only to 'real' forward
 	   arc, not rottorsoed one, but we let it pass this time */
-	/* This is wrong according to BMR 
+	/* This is wrong according to BMR
 	 *
 	 * Which states that the Torso twist is taken into account
 	 * as well as punching/axing/swords can attack in their
@@ -1313,14 +1315,14 @@ void PhysicalAttack(MECH * mech, int damageweight, int baseToHit,
 						  || swarmingUs,
 						  "Target is not in your forward or left side arc!");
 
-			}					// end 
+			}					// end
 
 		}						// end if/else() - club/punch arc check
 
 	}							// end if/else() - kick/punch arc check
 
 	/**
-     * Add in the movement modifiers 
+     * Add in the movement modifiers
      */
 
 	// If we have melee_specialist advantage, knock -1 off the BTH.
@@ -1368,7 +1370,7 @@ void PhysicalAttack(MECH * mech, int damageweight, int baseToHit,
 
     // Terrain mods - Courtesy of RST
     // Heavy & Light are from Total Warfare and
-    // Smoke from MaxTech old BMR 
+    // Smoke from MaxTech old BMR
     // Check Smoke first since it can sit on top of other terrain
     // Might want to check for Fire also at some point?
     if (MechTerrain(target) == SMOKE) {
@@ -1409,7 +1411,7 @@ void PhysicalAttack(MECH * mech, int damageweight, int baseToHit,
 	if(AttackType == PA_PUNCH)
 		MechSections(mech)[sect].config &= ~AXED;
 
-	// Clubbing recycles both arms. 
+	// Clubbing recycles both arms.
 	if(AttackType == PA_CLUB)
 		SetRecycleLimb(mech, LARM, PHYSICAL_RECYCLE_TIME);
 
@@ -1582,7 +1584,7 @@ void PhysicalDamage(MECH * mech, MECH * target, int weightdmg,
                     if ((MechType(target) != CLASS_MECH) || (Fallen(target) &&
                                 (MechElevation(mech) == MechElevation (target)))) {
                         hitloc = FindTargetHitLoc(mech, target, &isrear, &iscritical);
-                    } else if (!Fallen(target) && 
+                    } else if (!Fallen(target) &&
                             (MechElevation(mech) > MechElevation(target))) {
                         hitloc = FindPunchLocation(target, hitgroup);
                     } else if (MechElevation(mech) == MechElevation(target)) {

--- a/btech/src/btech/mech.pickup.c
+++ b/btech/src/btech/mech.pickup.c
@@ -12,6 +12,7 @@
 #include "config.h"
 #include <math.h>
 
+#include "glue.h"
 #include "mech.h"
 #include "mech.events.h"
 #include "muxevent.h"
@@ -53,7 +54,7 @@ void mech_pickup(dbref player, void *data, char *buffer)
 			"That target is not in your line of sight.");
 	DOCHECK(Fortified(target), "Your target is fortified and cannot be towed.");
 	DOCHECK(MechSpecials2(target) & CARRIER_TECH
-			&& !MechSpecials2(mech) & CARRIER_TECH,
+			&& !(MechSpecials2(mech) & CARRIER_TECH),
 			"You cannot handle the mass on that carrier.");
 	DOCHECK(CarryingClub(mech),
 			"You can't pickup while you're carrying a club!");
@@ -110,7 +111,7 @@ void mech_pickup(dbref player, void *data, char *buffer)
 /* Not on the same team, unit is !destroyed, don't allow.. Prevents picking up from heat shutdown, etc */
 /* Allow Team 0 (Administrative Team for Box Drops, etc) */
 	DOCHECK((MechTeam(mech) != MechTeam(target)) &&
-			(!Destroyed(target) && !Started(target) && MechTeam(target) != 0), 
+			(!Destroyed(target) && !Started(target) && MechTeam(target) != 0),
 			"You can't pick that up!");
 
 	if(Moving(target) && !Falling(target) && !OODing(target))

--- a/btech/src/btech/mech.sensor.c
+++ b/btech/src/btech/mech.sensor.c
@@ -7,6 +7,7 @@
  *       All rights reserved
  */
 
+#include "glue.h"
 #include "mech.h"
 #include "map.h"
 #define _MECH_SENSOR_C
@@ -246,7 +247,7 @@ int Sensor_Sees(MECH * mech, MECH * target, int f, int arc, float range,
 /* Main idea: If primary & secondary scanner differ,
    check both scanners for chance (with secondary at 1/2 chance).
    Also, if non-360degree scanners are used, check only forward arc for
-   them. 
+   them.
 
    If both same, multiply chance by 1.1
  */
@@ -511,7 +512,6 @@ void update_LOSinfo(dbref obj, MAP * map)
 			}
 	}
 	for(i = 1; i < map->first_free; i++) {
-		if(map->mechsOnMap[i] > 0);
 		mech = getMech(map->mechsOnMap[i]);
 		if(!mech)
 			continue;
@@ -532,7 +532,7 @@ void update_LOSinfo(dbref obj, MAP * map)
 				if(MechStatus2(mech) & SLITE_ON)
 					if(range < LITE_RANGE)
 						cause_lite(mech, target);
-/* for now, commenting out this if(Started... section 
+/* for now, commenting out this if(Started... section
  * it was causing problems with bap. so we update los a bit more often now
  */
 /*				if(Started(target))

--- a/btech/src/btech/mech.sensor.functions.c
+++ b/btech/src/btech/mech.sensor.functions.c
@@ -106,7 +106,7 @@ CSEEFUNC(electrom_csee, !(map->sensorflags & (1 << SENSOR_EM)) &&
 CSEEFUNC(seismic_csee,
 		 !(map->sensorflags & (1 << SENSOR_SE)) &&
 		 t && (!Jumping(m)) &&
-		 (mudconf.btech_seismic_see_stopped ? 1 : (abs(MechSpeed(t)) > MP1))
+		 (mudconf.btech_seismic_see_stopped ? 1 : (fabsf(MechSpeed(t)) > MP1))
 		 &&
 		 (((MechMove(m) != MOVE_VTOL)
 		   || ((MechMove(m) == MOVE_VTOL) && Landed(m)))
@@ -158,7 +158,7 @@ CSEEFUNC(blood_csee,
 #define WEIGHT_MODIFIER(a) (a > 65 ? -1 : a > 35 ? 0 : 1)
 
 /* If target's moving, +1 tohit */
-#define MOVE_MODIFIER(a) (abs(a) >= 10.75 ? 1 : 0)
+#define MOVE_MODIFIER(a) (fabsf(a) >= 10.75 ? 1 : 0)
 
 #define nwood_count(mech,a)  (MechLOSFlag_WoodCount(a) + \
                              ((MechElevation(mech) + 2) < MechZ(mech) ? 0 : \

--- a/btech/src/btech/mech.spot.c
+++ b/btech/src/btech/mech.spot.c
@@ -230,15 +230,15 @@ int FireSpot(dbref player,
 		DOCHECK0(InWater(target) && !(InWater(mech)),"You can't fire into water with that weapon from here.");
 
 		spotTerrain =
-			IsArtillery(weapontype) ? 2 : 1 + AddTerrainMod(spotter,
+			IsArtillery(weapontype) ? 2 : (1 + AddTerrainMod(spotter,
 															target,
 															mech_map,
 															spot_range,
 															0) +
-			AttackMovementMods(spotter) + (Locking(spotter)
+			AttackMovementMods(spotter) + ((Locking(spotter)
 										   && MechTargComp(spotter) !=
 										   TARGCOMP_MULTI)
-			? 2 : 0;
+			? 2 : 0));
 		DOCHECK1(IsArtillery(weapontype) &&
 				 target,
 				 "You can only target hexes with this kind of artillery.");
@@ -282,9 +282,9 @@ int FireSpot(dbref player,
 		FindRange(MechFX(mech), MechFY(mech), MechFZ(mech), enemyX, enemyY,
 				  enemyZ);
 	spotTerrain =
-		IsArtillery(weapontype) ? 2 : 1 + AttackMovementMods(spotter) +
-		(Locking(spotter) && MechTargComp(spotter) != TARGCOMP_MULTI)
-		? 2 : 0;
+		IsArtillery(weapontype) ? 2 : (1 + AttackMovementMods(spotter) +
+		((Locking(spotter) && MechTargComp(spotter) != TARGCOMP_MULTI)
+		? 2 : 0));
 	FireWeapon(mech, mech_map, target, 0, weapontype, weaponnum, section,
 			   critical, enemyX, enemyY, mapx, mapy, range, spotTerrain,
 			   sight, 2);

--- a/btech/src/btech/mech.stat.c
+++ b/btech/src/btech/mech.stat.c
@@ -13,14 +13,17 @@
 /* Make statistics 'bout what we do.. whatever it is we _do_ */
 
 #define MECH_STAT_C
+#include <time.h>
+#include <assert.h>
+
+#include "mech.h"
 #include "mech.stat.h"
 #include "db.h"
 #include "externs.h"
+#include "p.glue.h"
 
 #include "macros.h"
 #include "mt19937ar.h"
-#include <time.h>
-#include <assert.h>
 
 stat_type rollstat;
 
@@ -63,7 +66,7 @@ void do_show_stat(dbref player, dbref cause, int key, char *arg1, char *arg2)
 					  rollstat.rolls[i], f2, (int) optimalrolls, f1, chanceperc, 100.0 - chanceperc);
 	}
 	notify_printf(player, "Total rolls: %d", rollstat.totrolls);
-	
+
 /*	i = 0;
 
 	if(Wizard(player)) {
@@ -91,9 +94,9 @@ void do_show_stat(dbref player, dbref cause, int key, char *arg1, char *arg2)
 		hitavg    = ( (float) totalhitrolls[1] / (float) totalhitrolls[3]) * 100.0;
 		glanceavg = ( (float) totalhitrolls[2] / (float) totalhitrolls[3]) * 100.0;
 	}
-	notify_printf(player,"ALL  %8d (%5.1f%%)  %8d (%5.1f%%)  %8d (%5.1f%%)  %8d", 
+	notify_printf(player,"ALL  %8d (%5.1f%%)  %8d (%5.1f%%)  %8d (%5.1f%%)  %8d",
 		totalhitrolls[0], missavg, totalhitrolls[1], hitavg, totalhitrolls[2], glanceavg, totalhitrolls[3]);
-	
+
 	}
 */
 }

--- a/btech/src/btech/mech.status.c
+++ b/btech/src/btech/mech.status.c
@@ -15,6 +15,7 @@
 #include <math.h>
 #include <sys/file.h>
 
+#include "glue.h"
 #include "mech.h"
 #include "mech.events.h"
 #include "failures.h"
@@ -472,7 +473,7 @@ void PrintInfoStatus(dbref player, MECH * mech, int own)
 				(int) MechDesiredSpeed(mech), MechDesiredFacing(mech),
 				(int) (10. * MechMinusHeat(mech)));
 		notify(player, buff);
-		
+
 		if(MechLateral(mech))
 			notify_printf(player, "You are moving laterally %s",
 						  LateralDesc(mech));
@@ -553,7 +554,7 @@ void PrintInfoStatus(dbref player, MECH * mech, int own)
 //			notify(player, "  ");
 	}
 	notify(player, "  ");
-	// Show our locked target info (hex or unit).	
+	// Show our locked target info (hex or unit).
 	DisplayTarget(player, mech);
 
 	if(MechCarrying(mech) > 0)
@@ -665,7 +666,7 @@ void mech_status(dbref player, void *data, char *buffer)
 	}
 
 	// Show our heat bar by itself.
-	if(!doinfo && doheat && MechHasHeat(mech)) { 
+	if(!doinfo && doheat && MechHasHeat(mech)) {
 		PrintHeatBar(player, mech);
 	}
 
@@ -783,7 +784,7 @@ char *pos_part_name(MECH * mech, int index, int loop)
 			"Heatsink");
 	}
 
-        if (t == Special(SPLIT_CRIT_RIGHT) || t == Special(SPLIT_CRIT_LEFT)) { 
+        if (t == Special(SPLIT_CRIT_RIGHT) || t == Special(SPLIT_CRIT_LEFT)) {
 	                newindex = ReverseSplitCritLoc(mech, index, loop);
 	                newloop = GetPartData(mech, index, loop);
 	                if (newindex >= 0) {
@@ -906,7 +907,7 @@ char *sectstatus_func(MECH * mech, char *arg)
 	index = ArmorSectionFromString(MechType(mech), MechMove(mech), arg);
 	if(index == -1)
 		return "#-1 INVALID SECTION";
-	
+
 	sprintf(buffer, "%d", SectIsFlooded(mech,index) ? -1 : !(SectIsDestroyed(mech,index)));
 
 	return buffer;
@@ -990,12 +991,12 @@ char *armorstatus_func(MECH * mech, char *arg)
 }
 
 /* weaponstatus_func. Returns a string containing:
-   
+
    <weapon number> | <weapon (long) name> | <number of crits> |
    	<part quality> | <weapon recycle time> | <recycle time left> |
    	<weapon type> | <weapon status>
    [ , <next weapon> ]
-   	
+
    Weapon number is the number of the weapon in this particular 'mech.
    Long weapon name is 'agra.mediumlaser' and such.
    Weapon type is as defined in mech.h:
@@ -1184,7 +1185,7 @@ void CriticalStatus(dbref player, MECH * mech, int index)
 				if(wFireMode & WILL_JETTISON_MODE)
 					strcat(buffer, " (backpack)");
 
-			if (IsWeapon(type) && (wFireMode & REAR_MOUNT))	
+			if (IsWeapon(type) && (wFireMode & REAR_MOUNT))
 					strcat(buffer, " (R)");
 			if(!PartIsNonfunctional(mech, index, loop)) {
 				if(Special2I(type) == ARTEMIS_IV) {
@@ -1388,7 +1389,7 @@ void PrintWeaponStatus(MECH * mech, dbref player)
 
 		if(MechSpecials2(mech) & BLOODHOUND_PROBE_TECH)
 			sprintf(tempbuff + strlen(tempbuff), " BloodhoundProbe");
-		
+
 //		if(MechSpecials(mech) & LIGHT_BAP_TECH)
 //			sprintf(tempbuff + strlen(tempbuff), " LightBAP");
 
@@ -1734,7 +1735,7 @@ void PrintWeaponStatus(MECH * mech, dbref player)
  *
  * @<loc><char> = Show <char> only if location number <loc> is intact
  *
- * !<loc1><loc2><char> = Show <char> only if location number <loc1> or <loc2> 
+ * !<loc1><loc2><char> = Show <char> only if location number <loc1> or <loc2>
  *                       is intact
  *
  * TODO: Use the same escape character for everything.  Or provide a way to
@@ -1835,7 +1836,7 @@ static const char *const assaultmechdesc =
 
 #else /* WEIGHTVARIABLE_STATUS */
 
-/* 
+/*
   Bipedal BattleMech:
          ( 9)                 (**)                  ( 9)
       /99|99|99\           /99|99|99\            /99|99|99\
@@ -1893,14 +1894,14 @@ static const char *const mwdesc =
   Naval vehicle
 
          FRONT                    INTERNAL
-         ./99\.                    ./99\. 
+         ./99\.                    ./99\.
         |'.--.`|                  |'.--.`|
         |`|99|'|                  |`|99|'|
-        |\`--'/|                  |\`--'/|  
-        |99><99|                  |99><99|  
-        |./||\.|                  |./||\.|  
-        || 99 ||                  || 99 ||  
-         `~~~~'                    `~~~~' 
+        |\`--'/|                  |\`--'/|
+        |99><99|                  |99><99|
+        |./||\.|                  |./||\.|
+        || 99 ||                  || 99 ||
+         `~~~~'                    `~~~~'
 */
 
 static const char *const shipdesc =
@@ -1920,7 +1921,7 @@ static const char *const shipdesc =
          ./\.                       ./\.
       ___|99|___                 ___|99|___
       ---|><|---                 ---|><|---
-        ||99||                     ||99|| 
+        ||99||                     ||99||
      __|99::99|__               __|99::99|__
      --_|'99`|_--               --_|'99`|_--
         `~~~~'                     `~~~~'
@@ -1940,13 +1941,13 @@ static const char *const foildesc =
   Submarine vehicle:
 
         FRONT                     INTERNAL
-         --                         --      
-       =|99|=                     =|99|=    
-       |\__/|                     |\__/|    
-      | |99| |                   | |99| |   
-      |99||99|                   |99||99|   
-       \|--|/                     \|--|/    
-       =|99|=                     =|99|=    
+         --                         --
+       =|99|=                     =|99|=
+       |\__/|                     |\__/|
+      | |99| |                   | |99| |
+      |99||99|                   |99||99|
+       \|--|/                     \|--|/
+       =|99|=                     =|99|=
 */
 
 static const char *const subdesc =
@@ -2005,14 +2006,14 @@ static const char *const spher_ds_desc =
 
 /*
   Aerodine Dropship
-       .--.     
-     ,`.99.'.   
-     |.|__|.|   
-    | | 99 | |  
-    | |:  :| |  
-   |'99|--|99`| 
-   |  .'99`.  | 
-   `|`_\~~/_`|' 
+       .--.
+     ,`.99.'.
+     |.|__|.|
+    | | 99 | |
+    | |:  :| |
+   |'99|--|99`|
+   |  .'99`.  |
+   `|`_\~~/_`|'
 */
 
 static const char *const aerod_ds_desc =
@@ -2068,15 +2069,15 @@ static const char *const veh_not_desc =
 /*
   VTOL
         FRONT                               INTERNAL
-     .   ..   .                            .   ..   .   
-     \\ `__` //                            \\ `__` //   
-      \\.99.//                              \\.99.//    
-     __\\  //__                            __\\  //__   
-    (99|(99)|99)                          (99|(99)|99)  
-    *--|// \\--*                          *--|// \\--*  
-       //99 \\                               //99 \\    
-      //\__/ \\                             //\__/ \\   
-      ~       ~                             ~       ~   
+     .   ..   .                            .   ..   .
+     \\ `__` //                            \\ `__` //
+      \\.99.//                              \\.99.//
+     __\\  //__                            __\\  //__
+    (99|(99)|99)                          (99|(99)|99)
+    *--|// \\--*                          *--|// \\--*
+       //99 \\                               //99 \\
+      //\__/ \\                             //\__/ \\
+      ~       ~                             ~       ~
 */
 
 
@@ -2092,7 +2093,7 @@ static const char *const vtoldesc =
     "7      @5/@5/@3\\@3_@3_@3/ @5\\@5\\                             @5/@5/@3\\@3_@3_@3/ @5\\@5\\   \n"
     "7      @5~       @5~                             @5~       @5~";
 
-/* 
+/*
  Battlesuit
 
  SQUAD STATUS
@@ -2318,7 +2319,7 @@ ArmorKeyInfo(dbref player, int line_key, int owner)
 static char *
 show_armor(MECH *mech, const int loc, const int flag, int width)
 {
-	/* XXX: color_string must be 6 chars or less.  */ 
+	/* XXX: color_string must be 6 chars or less.  */
 	static char fieldbuf[6 + 23 + 2 + 1];
 
 	char *fbp = fieldbuf;

--- a/btech/src/btech/mech.tech.commands.c
+++ b/btech/src/btech/mech.tech.commands.c
@@ -18,7 +18,10 @@
 #include "p.mech.tech.h"
 #include "p.mech.consistency.h"
 #include "p.mech.tech.do.h"
+#include "p.mech.status.h"
+#include "p.econ.h"
 #include "p.bsuit.h"
+#include "p.btechstats.h"
 
 #define my_parsepart(loc,part) \
 switch (tech_parsepart(mech, buffer, loc, part,NULL)) \
@@ -344,7 +347,7 @@ TECHCOMMANDH(tech_removesection)
 TECHCOMMANDH(tech_replacegun)
 {
 	int brand = 0, ob = 0;
-        
+
 	int base, roll , rollmod, fixtime, base_fixtime, parttype, oparttype, fail_fixtime;
 
 	TECHCOMMANDB;
@@ -484,7 +487,7 @@ TECHCOMMANDH(tech_repairgun)
 		notify(player, "That gun isn't hurtin'!");
 		return;
 	}
-        
+
 	DOCHECK(player_techtime(player) >= mudconf.btech_maxtechtime, "You're too tired to do that!");
 
 	DOTECH_LOCPOS(REPAIR_DIFFICULTY + WEAPTYPE_DIFFICULTY(GetPartType(mech,
@@ -521,7 +524,7 @@ TECHCOMMANDH(tech_fixenhcrit)
 		notify(player, "That gun isn't damaged!");
 		return;
 	}
-        
+
 	DOCHECK(player_techtime(player) >= mudconf.btech_maxtechtime, "You're too tired to do that!");
 
 	DOTECH_LOCPOS(ENHCRIT_DIFFICULTY,
@@ -565,16 +568,16 @@ TECHCOMMANDH(tech_replacepart)
 
 /* little cheating here to get the proper part, since we aren't doing complex repairs */
 	oparttype=GetPartType(mech,loc,part);
-	parttype =   (IsActuator(oparttype) ? Cargo(S_ACTUATOR) : 
-	   (oparttype == Special(ENGINE) ? 
-	       ((MechSpecials(mech) & XL_TECH) ? Cargo(XL_ENGINE) : 
-	            (MechSpecials(mech) & ICE_TECH) ? Cargo(IC_ENGINE) : 
-		         (MechSpecials(mech) & XXL_TECH) ? Cargo(XXL_ENGINE) : 
-			      (MechSpecials(mech) & CE_TECH) ? Cargo(COMP_ENGINE) : 
-			           (MechSpecials(mech) & LE_TECH) ? Cargo(LIGHT_ENGINE) : oparttype) : 
+	parttype =   (IsActuator(oparttype) ? Cargo(S_ACTUATOR) :
+	   (oparttype == Special(ENGINE) ?
+	       ((MechSpecials(mech) & XL_TECH) ? Cargo(XL_ENGINE) :
+	            (MechSpecials(mech) & ICE_TECH) ? Cargo(IC_ENGINE) :
+		         (MechSpecials(mech) & XXL_TECH) ? Cargo(XXL_ENGINE) :
+			      (MechSpecials(mech) & CE_TECH) ? Cargo(COMP_ENGINE) :
+			           (MechSpecials(mech) & LE_TECH) ? Cargo(LIGHT_ENGINE) : oparttype) :
 				      (oparttype == Special(HEAT_SINK) && MechHasDHS(mech) ? Cargo(DOUBLE_HEAT_SINK) : oparttype)));
 
-	
+
 
 	DOCHECK(IsAmmo(GetPartType(mech,loc,part)) ? 0 : econ_find_items(IsDS(mech) ? AeroBay(mech,0) : Location(mech->mynum), parttype,GetPartBrand(mech,loc,part)) < 1 ,
 			tprintf("Not enough units of %s in store.",part_name(parttype,GetPartBrand(mech,loc,part))));
@@ -619,7 +622,7 @@ TECHCOMMANDH(tech_replacepart)
 			fixtime = mudconf.btech_variable_techtime ? (base_fixtime * 10 ) / (1000 / (100 - (roll ? mudconf.btech_techtime_mod * roll : 0 ))) : base_fixtime;
 		if(base_fixtime - fixtime)
 			notify_printf(player,"Your skill manages to save %d minute%s", base_fixtime - fixtime, base_fixtime - fixtime == 1 ? "!" : "s!");
-		
+
 		econ_change_items(IsDS(mech) ? AeroBay(mech,0) : Location(mech->mynum), parttype,GetPartBrand(mech,loc,part),-1);
 		tech_addtechtime(player, fixtime);
 		muxevent_add(MAX(1, player_techtime(player)*TECH_TICK), 0, EVENT_REPAIR_REPL, muxevent_tickmech_repairpart, (void *) mech, (void *) (PACK_LOCPOS(loc,part) + player * PLAYERPOS));
@@ -659,7 +662,7 @@ TECHCOMMANDH(tech_repairpart)
 			"Someone's scrapping that section - no repairs are possible!");
         DOCHECK(player_techtime(player) >= mudconf.btech_maxtechtime, "You're too tired to do that!");
 
-	
+
 
 
 
@@ -730,7 +733,7 @@ TECHCOMMANDH(tech_reload)
 		GetPartAmmoMode(mech, loc, part) |= t;
 	}
 	change = 0;
-        
+
 	DOCHECK(player_techtime(player) >= mudconf.btech_maxtechtime, "You're too tired to do that!");
 
 	DOTECH_LOCPOS_VAL(RELOAD_DIFFICULTY, reload_fail, reload_succ,
@@ -805,7 +808,7 @@ TECHCOMMANDH(tech_fixarmor)
 	from = MIN(to, from);
 	DOCHECK(from == to, "The location doesn't need armor repair!");
 	change = to - from;
-	ochange = change;	
+	ochange = change;
 	DOCHECK(player_techtime(player) >= mudconf.btech_maxtechtime, "You're too tired to do that!");
 	DOTECH_LOC_VAL_S(FIXARMOR_DIFFICULTY, fixarmor_fail, fixarmor_succ,
 					 fixarmor_econ, &change, FIXARMOR_TIME * ochange, loc,

--- a/btech/src/btech/mech.tech.damages.c
+++ b/btech/src/btech/mech.tech.damages.c
@@ -25,6 +25,7 @@
 #include "p.mech.tech.commands.h"
 #include "p.mech.status.h"
 #include "p.mech.build.h"
+#include "p.btechstats.h"
 
 /* 0 = type, 1 = loc, 2 = (pos/amnt), 3 = (val) */
 short damage_table[MAX_DAMAGES][3];
@@ -392,7 +393,7 @@ void show_mechs_damage(dbref player, void *data, char *buffer)
                         sprintf(buf, repair_need_msgs[(int) damage_table[i][0]],
                                         pos_part_name(mech, v1, v2));
                         break;
-		case REPAIRP_T:	
+		case REPAIRP_T:
 			if(GetWeaponCrits(mech, Weapon2I(GetPartType(mech, v1, v2))) < 5)
 				extra_hard = 0;
                         fix_bth = char_getskilltarget(player, "technician-weapons", 0) + REPLACE_DIFFICULTY + WEAPTYPE_DIFFICULTY(GetPartType(mech,v1,v2)) + extra_hard;
@@ -400,7 +401,7 @@ void show_mechs_damage(dbref player, void *data, char *buffer)
                         sprintf(buf, repair_need_msgs[(int) damage_table[i][0]],
                                         pos_part_name(mech, v1, v2));
                         break;
-		case REPAIRG:                
+		case REPAIRG:
 			fix_bth = char_getskilltarget(player, "technician-weapons", 0) + REPLACE_DIFFICULTY + WEAPTYPE_DIFFICULTY(GetPartType(mech,v1,v2));
 			fix_time = REPLACEGUN_TIME * ClanMod(GetWeaponCrits(mech, Weapon2I(GetPartType(mech, v1, v2))));
                         sprintf(buf, repair_need_msgs[(int) damage_table[i][0]],
@@ -433,7 +434,7 @@ void show_mechs_damage(dbref player, void *data, char *buffer)
 		case RELOAD:
 			sprintf(buf, repair_need_msgs[(int) damage_table[i][0]],
 					pos_part_name(mech, v1, v2), GetPartAmmoMode(mech,v1,v2) ?
-					GetAmmoDesc_Model_Mode(Ammo2WeaponI(GetPartType(mech,v1,v2)),GetPartAmmoMode(mech,v1,v2)) : "", 
+					GetAmmoDesc_Model_Mode(Ammo2WeaponI(GetPartType(mech,v1,v2)),GetPartAmmoMode(mech,v1,v2)) : "",
 					FullAmmo(mech, v1, v2) - GetPartData(mech, v1, v2) );
 			fix_time = RELOAD_TIME;
 			fix_bth = FindTechSkill(player, mech) + RELOAD_DIFFICULTY;
@@ -441,7 +442,7 @@ void show_mechs_damage(dbref player, void *data, char *buffer)
 		case UNLOAD:
 			sprintf(buf, repair_need_msgs[(int) damage_table[i][0]],
 					pos_part_name(mech, v1, v2), GetPartAmmoMode(mech,v1,v2) ?
-					GetAmmoDesc_Model_Mode(Ammo2WeaponI(GetPartType(mech,v1,v2)),GetPartAmmoMode(mech,v1,v2)) : "", 
+					GetAmmoDesc_Model_Mode(Ammo2WeaponI(GetPartType(mech,v1,v2)),GetPartAmmoMode(mech,v1,v2)) : "",
 					GetPartData(mech, v1, v2));
 			fix_time = RELOAD_TIME;
 			fix_bth = FindTechSkill(player, mech) + REMOVES_DIFFICULTY;
@@ -450,16 +451,16 @@ void show_mechs_damage(dbref player, void *data, char *buffer)
 		case FIXARMOR_R:
 		case FIXINTERNAL:
 			sprintf(buf, repair_need_msgs[(int) damage_table[i][0]],
-					damage_table[i][0] == FIXINTERNAL ? 
+					damage_table[i][0] == FIXINTERNAL ?
 					((MechSpecials(mech) & ES_TECH) ? " Endosteel" :
-					(MechSpecials(mech) & REINFI_TECH) ? " Reinforced" : 
+					(MechSpecials(mech) & REINFI_TECH) ? " Reinforced" :
 					(MechSpecials(mech) & COMPI_TECH) ? " Composite" :
 							            "" ) :
 				       ((MechSpecials(mech) & FF_TECH) ? " Ferrofibrous":
 				       (MechSpecials(mech) & HARDA_TECH) ? " Hardened" :
 				       (MechSpecials2(mech) & STEALTH_ARMOR_TECH) ? " Stealth" :
 				       (MechSpecials2(mech) & HVY_FF_ARMOR_TECH) ? " Heavy Ferrofibrous" :
-				       (MechSpecials2(mech) & LT_FF_ARMOR_TECH) ? " Light Ferrofibrous" : 
+				       (MechSpecials2(mech) & LT_FF_ARMOR_TECH) ? " Light Ferrofibrous" :
 				       (MechInfantrySpecials(mech) & CS_PURIFIER_STEALTH_TECH) ? " Purifier Stealth" : ""),
 					damage_table[i][2]);
 			fix_bth = FindTechSkill(player, mech) + (damage_table[i][0] == FIXINTERNAL ? FIXINTERNAL_DIFFICULTY : FIXARMOR_DIFFICULTY);
@@ -472,7 +473,7 @@ void show_mechs_damage(dbref player, void *data, char *buffer)
 		} else {
 			sprintf(buf3, "%4d %4d", fix_time, fix_bth);
 		}
-		sprintf(buf2, "%%ch%s%3s %3d %9s %3s %s%%cn", j ? "%cg" : "%cy", j ? "(*)" :"",
+		sprintf(buf2, "%%ch%s%3s %3d %9s %3s %s%%cn%s", j ? "%cg" : "%cy", j ? "(*)" :"",
 				i + 1,
 				buf3,
 				ShortArmorSectionString(MechType(mech), MechMove(mech), v1),

--- a/btech/src/btech/mech.update.c
+++ b/btech/src/btech/mech.update.c
@@ -13,6 +13,7 @@
 #include <math.h>
 #include <sys/file.h>
 
+#include "glue.h"
 #include "mech.h"
 #include "failures.h"
 #include "mech.events.h"
@@ -478,7 +479,7 @@ void move_mech(MECH * mech)
 			MechFZ(mech) += MechStartFZ(mech) * MOVE_MOD;
 			MechZ(mech) = MechFZ(mech) / ZSCALE;
 			MechFX(mech) += MechStartFX(mech) * MOVE_MOD;
-			MechFY(mech) += MechStartFY(mech) * MOVE_MOD;			
+			MechFY(mech) += MechStartFY(mech) * MOVE_MOD;
 
 			/*! \todo {Need to rewrite this for aerodyne DSes unless they're
 			 * set as large aeros which i'm not sure but either way its
@@ -662,7 +663,7 @@ void move_mech(MECH * mech)
 			NewHexEntered(mech, mech_map, newx, newy, last_z);
 
 		if(MechX(mech) == x && MechY(mech) == y) {
-// Removed MarkForLOSUpdate.. Moved to NewHexEntered to clear potential false positives. 
+// Removed MarkForLOSUpdate.. Moved to NewHexEntered to clear potential false positives.
 //			MarkForLOSUpdate(mech);
 			MechFloods(mech);
 			water_extinguish_inferno(mech);
@@ -724,7 +725,7 @@ void move_mech(MECH * mech)
 	 * position in relation to its target */
 	BSuitMirrorSwarmedTarget(mech_map, mech);
 
-	/* This is really for killing MechWarriors 
+	/* This is really for killing MechWarriors
 	 * actual heat code is checked with UpdateHeat */
 	fiery_death(mech);
 }
@@ -899,7 +900,7 @@ void UpdateHeading(MECH * mech)
 	if(normangle > SHO2FSIM(180)) {
 		AddRFacing(mech, offset);
 		if(MechFacing(mech) >= 360)
-			AddFacing(mech, -360);
+			SetRFacing(mech, MechFacing(mech) % 360);
 		normangle += offset;
 		if(normangle >= SHO2FSIM(360))
 			SetRFacing(mech, SHO2FSIM(MechDesiredFacing(mech)));
@@ -1047,7 +1048,7 @@ void UpdateSpeed(MECH * mech)
 				/* dif = 2 to 7 */
 				/* Hack to get turnmode tight to lower more speed */
 				if(GetTurnMode(mech))
-					tempspeed = (tempspeed * (10 - dif) / 10) - (MP1 * 0.4); 
+					tempspeed = (tempspeed * (10 - dif) / 10) - (MP1 * 0.4);
 				else
 					tempspeed = tempspeed * (10 - dif) / 10; /* Lower 20-80% */
 			}
@@ -1311,7 +1312,7 @@ void HandleOverheat(MECH * mech)
 			domino_space(mech, 2);
 		} else {
 			MechLOSBroadcast(mech, "stops in mid-motion!");
-			if((fabs(MechSpeed(mech) > MP1)) && !Fallen(mech) &&
+			if((fabs(MechSpeed(mech)) > MP1) && !Fallen(mech) &&
 			   (!MadePilotSkillRoll(mech, 3)))
 				MechFalls(mech, 0, 1);
 		}
@@ -1333,7 +1334,7 @@ static int EnableSomeHS(MECH * mech, int numsinks)
 		return 0;
 
 	MechDisabledHS(mech) -= numsinks;
-	MechMinusHeat(mech) += numsinks;	/* We dont check for water and 
+	MechMinusHeat(mech) += numsinks;	/* We dont check for water and
 										   such after enabling them, only the next tic. */
 #ifdef HEATCUTOFF_DEBUG
 	mech_printf(mech, MECHALL,
@@ -1356,7 +1357,7 @@ static int DisableSomeHS(MECH * mech, int numsinks)
 		return 0;
 
 	MechDisabledHS(mech) += numsinks;
-	MechMinusHeat(mech) -= numsinks;	/* Submerged heatsinks silently 
+	MechMinusHeat(mech) -= numsinks;	/* Submerged heatsinks silently
 										   still dissipate some heat */
 #ifdef HEATCUTOFF_DEBUG
 	mech_printf(mech, MECHALL,
@@ -1367,7 +1368,7 @@ static int DisableSomeHS(MECH * mech, int numsinks)
 	return numsinks;
 }
 
-/* Update the Unit's current heat values as well as 
+/* Update the Unit's current heat values as well as
  * send messages to the pilot based on heat level */
 void UpdateHeat(MECH * mech)
 {
@@ -1379,7 +1380,7 @@ void UpdateHeat(MECH * mech)
 	MAP *map;
 
 	// These guys don't get heat updates.
-	if(!MechHasHeat(mech)) 
+	if(!MechHasHeat(mech))
 		return;
 
 	inheat = MechHeat(mech);
@@ -1748,7 +1749,7 @@ void NewHexEntered(MECH * mech, MAP * mech_map, float deltax, float deltay,
                         MadePilotSkillRoll_NoXP(mech,
                             (int) (fabs((MechSpeed (mech)) + MP1) / MP1) / 3, 1))
 			   || (mudconf.btech_skidcliff &&
-                    MadePilotSkillRoll_NoXP(mech, 
+                    MadePilotSkillRoll_NoXP(mech,
                         SkidMod(fabs(MechSpeed(mech)) / MP1), 1))) {
 
 				mech_notify(mech, MECHALL,
@@ -1961,7 +1962,7 @@ void NewHexEntered(MECH * mech, MAP * mech_map, float deltax, float deltay,
                         MadePilotSkillRoll_NoXP(mech,
                             (int) (fabs((MechSpeed (mech)) + MP1) / MP1) / 3, 1))
 			   || (mudconf.btech_skidcliff &&
-                    MadePilotSkillRoll_NoXP(mech, 
+                    MadePilotSkillRoll_NoXP(mech,
                         SkidMod(fabs(MechSpeed(mech)) / MP1), 1))) {
 
 				mech_notify(mech, MECHALL,
@@ -2150,7 +2151,7 @@ void NewHexEntered(MECH * mech, MAP * mech_map, float deltax, float deltay,
                         MadePilotSkillRoll_NoXP(mech,
                             (int) (fabs((MechSpeed (mech)) + MP1) / MP1) / 3, 1))
 			   || (mudconf.btech_skidcliff &&
-                    MadePilotSkillRoll_NoXP(mech, 
+                    MadePilotSkillRoll_NoXP(mech,
                         SkidMod(fabs(MechSpeed(mech)) / MP1), 1))) {
 
 				mech_notify(mech, MECHALL,
@@ -2397,7 +2398,7 @@ void NewHexEntered(MECH * mech, MAP * mech_map, float deltax, float deltay,
                         MadePilotSkillRoll_NoXP(mech,
                             (int) (fabs((MechSpeed (mech)) + MP1) / MP1) / 3, 1))
 			   || (mudconf.btech_skidcliff &&
-                    MadePilotSkillRoll_NoXP(mech, 
+                    MadePilotSkillRoll_NoXP(mech,
                         SkidMod(fabs(MechSpeed(mech)) / MP1), 1))) {
 
 				mech_notify(mech, MECHALL,
@@ -2575,7 +2576,7 @@ void NewHexEntered(MECH * mech, MAP * mech_map, float deltax, float deltay,
 
 	case MOVE_VTOL:
 	case MOVE_FLY:
-		
+
 		if((Landed(mech) && MechRTerrain(mech) != ROAD &&
 		   MechRTerrain(mech) != BRIDGE && MechRTerrain(mech) != GRASSLAND
 		   && MechRTerrain(mech) != BUILDING) ||
@@ -2714,7 +2715,7 @@ void MarkStaggerDamage(MECH * mech, int staggerLevel)
   }
 }
 
-// This method will clear any damage that has happened for staggerLevel * 20 
+// This method will clear any damage that has happened for staggerLevel * 20
 // If you are on staggerLevel = 1, this is 20-39 points of damage.
 void RemoveStaggerDamage(MECH * mech, int staggerLevel)
 {
@@ -2722,7 +2723,7 @@ void RemoveStaggerDamage(MECH * mech, int staggerLevel)
   struct damageNode *old;
   int remove = staggerLevel * 20;
   int sum = 0;
-  
+
   damage = (mech)->rd.staggerDamageList;
 
   while(sum < remove && damage != NULL) {
@@ -2796,7 +2797,7 @@ int CurrentCountedStaggerDamage(MECH * mech)
   time_t now = mudstate.now;
   int oneTurn = 60;
   struct damageNode *damage;
-  
+
   damage = (mech)->rd.staggerDamageList;
   while(damage != NULL) {
     if(now - damage->occuredAt <= oneTurn) {
@@ -2849,14 +2850,14 @@ void UpdatePilotSkillRolls(MECH * mech)
 {
 	int makeroll = 0, grav = 0;
 	float maxspeed;
-	
+
 	int temp_tick = muxevent_tick;
 
 	/* If for some reason, we get here and muxevent_tick is odd all the time.... */
 	if ((temp_tick & 1) != 0 )
 		temp_tick++;
-	
-	
+
+
 	if(((temp_tick % TURN) == 0) && !Fallen(mech) && !Jumping(mech) &&
 	   !OODing(mech))
 		/* do this once a turn (30 secs), only if mech is standing */

--- a/btech/src/btech/mine.c
+++ b/btech/src/btech/mine.c
@@ -3,7 +3,7 @@
  *
  *  Copyright (c) 1996 Markus Stenberg
  *  Copyright (c) 1998-2002 Thomas Wouters
- *  Copyright (c) 2000-2002 Cord Awtry 
+ *  Copyright (c) 2000-2002 Cord Awtry
  *       All rights reserved
  */
 
@@ -11,7 +11,7 @@
    Different types of mines:
 
    1 = Standard round (infinite explosions, same damage, to everyone in hex)
-   2 = Inferno        (single explosion, adds heat instead) 
+   2 = Inferno        (single explosion, adds heat instead)
    3 = Command-detonated (single explosion, goes off when hears transmission
    on predefined freq - damages neighbor hexes 1/2)
    4 = Vibra          (single explosion, triggered by weight (setting):
@@ -23,6 +23,7 @@
 #include "copyright.h"
 #include "config.h"
 #include <math.h>
+#include "glue.h"
 #include "mech.h"
 #include "mine.h"
 #include "p.artillery.h"
@@ -36,14 +37,14 @@
  *
  * The Trigger mines are used to let the MUX
  * know if a unit has moved to a certain spot
- * 
+ *
  * The others are the explosive do damage kind */
 char *mine_type_names[] = {
 	"Standard",
 	"Inferno",
 	"Command",
 	"Vibra",
-	"Trigger",	
+	"Trigger",
 	NULL
 };
 
@@ -151,7 +152,7 @@ void make_mine_explode(MECH * mech, MAP * map, mapobj * o, int x, int y,
 		// Trigger the unit's AMECHDEST attribute.
 		if(mech->mynum > 0)
 		    did_it(mech->mynum, mech->mynum, 0, NULL, 0, NULL, A_AMINETRIGGER, (char **) NULL, 0);
-		
+
 		return;
 	case MINE_VIBRA:
 		unset_hex_mine(map, o->x, o->y);

--- a/btech/src/btech/p.mech.update.h
+++ b/btech/src/btech/p.mech.update.h
@@ -34,10 +34,12 @@ int recycle_weaponry(MECH * mech);
 int SkidMod(float Speed);
 void NewHexEntered(MECH * mech, MAP * mech_map, float deltax, float deltay,
     int last_z);
+void MarkStaggerDamage(MECH * mech, int staggerLevel);
 void RemoveStaggerDamage(MECH * mech, int staggerLevel);
 void ClearAllStaggerDamage(MECH * mech);
 void ClearStaggerDamage(MECH * mech);
 int CurrentStaggerDamage(MECH * mech);
+int CurrentCountedStaggerDamage(MECH * mech);
 void CheckDamage(MECH * wounded);
 void UpdatePilotSkillRolls(MECH * mech);
 void updateAutoturnTurret(MECH * mech);

--- a/btech/src/btech/p.mech.utils.h
+++ b/btech/src/btech/p.mech.utils.h
@@ -11,6 +11,9 @@ char *MechIDS(MECH * mech, int islower);
 char *MyToUpper(char *string);
 void MarkForLOSUpdate(MECH * mech);
 
+int round_to_halfton(int weight);
+int round_to_quarterton(int weight);
+
 /* Self-inflicted kill types. (But flood might be accidental/intentional.) */
 #define KILL_TYPE_SELF_DESTRUCT "SELF-DESTRUCT"
 #define KILL_TYPE_EJECT 	"EJECT"
@@ -131,7 +134,7 @@ void mech_FillPartAmmo(MECH * mech, int loc, int pos);
 int CountDestroyedLegs(MECH * objMech);
 int IsLegDestroyed(MECH * objMech, int wLoc);
 int IsMechLegLess(MECH * objMech);
-int FindFirstWeaponCrit(MECH * objMech, int wLoc, int wSlot, int wStartSlot, 
+int FindFirstWeaponCrit(MECH * objMech, int wLoc, int wSlot, int wStartSlot,
    int wCritType, int wMaxCrits);
 int checkAllSections(MECH * mech, int specialToFind);
 int checkSectionForSpecial(MECH * mech, int specialToFind, int wSec);

--- a/btech/src/btech/template.c
+++ b/btech/src/btech/template.c
@@ -3,7 +3,7 @@
  *	All rights reserved
  */
 
-/* 
+/*
    Code to read and write mech and vehicle templates
    Created by Nim 9/16/96
 
@@ -27,6 +27,7 @@
 #include <string.h>
 #include <ctype.h>
 
+#include "glue.h"
 #include "mech.h"
 #include "create.h"
 #include "mech.events.h"
@@ -37,6 +38,7 @@
 #include "p.mech.utils.h"
 #include "p.mech.partnames.h"
 #include "p.mech.consistency.h"
+#include "p.mech.update.h"
 #include "p.map.conditions.h"
 #include "p.aero.bomb.h"
 #include "p.mech.mechref_ident.h"
@@ -1202,7 +1204,7 @@ char *specials2[] = {
 	"XLGyro_Tech",
 	"HDGyro_Tech",
 	"CompactGyro_Tech",
-	"TargComp_Tech",	
+	"TargComp_Tech",
 	"SmallCockpit_Tech",
 	NULL
 };
@@ -1215,7 +1217,7 @@ char *specialsabrev2[] = {
 	"CART",
 	"WPRF",
 	"XLGYRO", "HDGYRO", "CGYRO",
-	"TCOMP", "SMCPIT", 
+	"TCOMP", "SMCPIT",
 	NULL
 };
 
@@ -2682,7 +2684,7 @@ int load_template(dbref player, MECH * mech, char *filename)
 	if(strlen(MechUnitTRO(mech)) == 0 ) {
 		tmpc = "Undefined";
 		strcpy(MechUnitTRO(mech), tmpc);
-	}		
+	}
 #define Set(a,b) \
 		if (!(a)) a = b
 	if(!(MechSpecials(mech) & ICE_TECH))
@@ -2974,7 +2976,7 @@ char *payloadlist_func(MECH * mech)
 				} /*end part is destroyed check */
 			}
 			/* End of is it Ammo if Statement */
-		
+
 		}						/* End of Crit Slot Loop */
 
 	}							/* End of Section Loop */
@@ -3007,7 +3009,7 @@ char *payloadlist_func(MECH * mech)
 	return buffer;
 }
 
-//Borrowed from payload_func 
+//Borrowed from payload_func
 char *partlist_func(MECH * mech)
 {
 	static char buffer[LBUF_SIZE];
@@ -3046,7 +3048,7 @@ char *partlist_func(MECH * mech)
 				continue;
 
 /*	Things we don't need */
-			if(IsAmmo(temp_crit)) 
+			if(IsAmmo(temp_crit))
 				continue;
 			if(IsWeapon(temp_crit))
 				continue;
@@ -3098,10 +3100,10 @@ char *partlist_func(MECH * mech)
 				sprintf(partlistbuff, "%s:%d", MechSpecials(mech) & LE_TECH ? "Light_Engine" :
 							MechSpecials(mech) & CE_TECH ? "Compact_Engine" :
 							MechSpecials(mech) & XXL_TECH ? "XXL_Engine" :
-							MechSpecials(mech) & XL_TECH ? "XL_Engine" : 
+							MechSpecials(mech) & XL_TECH ? "XL_Engine" :
 							MechSpecials(mech) & ICE_TECH ? "ICE_Engine" :"Engine",
 								partlist_count[put_loop]);
-			
+
 				/* If we are not at the end, then put a | as a spacer */
 				if(put_loop < (part_count - 1)) {
 				strncat(partlistbuff, "|", sizeof(buffer) - strlen(buffer) - 1);
@@ -3152,7 +3154,7 @@ char *partlist_func(MECH * mech)
 
 			break;
 			}
-		
+
 	} /* end printing loop */
 	if (act_count) {
 		sprintf(partlistbuff,"|Actuator:%d",act_count);

--- a/btech/src/glue.c
+++ b/btech/src/glue.c
@@ -5,8 +5,8 @@
  * Original author: unknown
  *
  * Copyright (c) 1996-2002 Markus Stenberg
- * Copyright (c) 1998-2002 Thomas Wouters 
- * Copyright (c) 2000-2002 Cord Awtry 
+ * Copyright (c) 1998-2002 Thomas Wouters
+ * Copyright (c) 2000-2002 Cord Awtry
  *
  * Last modified: Thu Jul  9 02:40:16 1998 fingon
  *
@@ -405,7 +405,7 @@ load_update1(void *key, void *data, int depth, void *arg)
 
 		if(!FlyingT(mech) && Started(mech) && Jumping(mech))
 			mech_Rsetxy(GOD, (void *) mech, tprintf("%d %d", MechX(mech),MechY(mech)));
-	
+
 		MechStatus(mech) &= ~(BLINDED | UNCONSCIOUS | JUMPING | TOWED);
 		MechSpecials2(mech) &=
 			~(ECM_ENABLED | ECM_DISTURBANCE | ECM_PROTECTED |
@@ -421,11 +421,19 @@ load_update1(void *key, void *data, int depth, void *arg)
 		// ClearStaggerDamage
 		mech->rd.staggerDamageList = NULL;
 		if(!(MechXPMod(mech)))
-			MechXPMod(mech) = 1;		
+			MechXPMod(mech) = 1;
 		for(i = 0; i < FREQS; i++)
 			if(mech->freq[i] < 0)
 				mech->freq[i] = 0;
 		break;
+	case GTYPE_DEBUG:
+	case GTYPE_MECHREP:
+	case GTYPE_AUTO:
+	case GTYPE_TURRET:
+	case GTYPE_UNUSED1:
+	default:
+    /* do nothing with these types */
+	break;
 	}
 	return 1;
 }
@@ -689,8 +697,8 @@ save_maps_func(void *key, void *data, int depth, void *arg)
 	return 1;
 }
 
-/* 
- * Save any extra info for the autopilots 
+/*
+ * Save any extra info for the autopilots
  *
  * Like their command lists
  * or the Astar path if there is one
@@ -923,15 +931,16 @@ UpdateSpecialObjects(void)
 void *
 NewSpecialObject(long id, int type)
 {
-	XCODE *xcode_obj;
-
-	long i;
+	XCODE *xcode_obj = NULL;
 
 	if(SpecialObjects[type].datasize) {
-		Create(xcode_obj, char, (i = SpecialObjects[type].datasize));
-
+		xcode_obj = (XCODE *)calloc(1, SpecialObjects[type].datasize);
+		if (!xcode_obj) {
+		  printf("Unable to calloc\n");
+		  exit(1);
+		}
 		xcode_obj->type = type;
-		xcode_obj->size = i;
+		xcode_obj->size = SpecialObjects[type].datasize;
 
 		if(SpecialObjects[type].allocfreefunc)
 			SpecialObjects[type].allocfreefunc(id, &xcode_obj, SPECIAL_ALLOC);
@@ -1589,9 +1598,9 @@ void mecha_notify_except(dbref loc, dbref player, dbref exception, char *msg)
 	}
 }
 
-/* 
+/*
    Basically, finish all the repairs etc in one fell swoop. That's the
-   best we can do for now, I'm afraid. 
+   best we can do for now, I'm afraid.
    */
 void ResetSpecialObjects()
 {

--- a/btech/src/include/glue.h
+++ b/btech/src/include/glue.h
@@ -323,7 +323,7 @@ CommandsStruct mechcommands[] = {
     {0, "LBX <weapnum>", "Sets weapon to and from LBX Mode.", mech_lbx},
     {0, "NARC <weapnum>", "Sets weapon to and from NARC Mode.", mech_narc},
     {0, "SGUIDED <weapnum>", "Sets weapon to and from Sguide Mode", mech_sguided},
-    {0, "STINGER <weaponum>", "Sets weapon to and from Stinger Mode.", 
+    {0, "STINGER <weaponum>", "Sets weapon to and from Stinger Mode.",
         mech_stinger},
     {0, "ATMRANGE <weapnum>", "Sets weapon to and from Extended Range Mode", mech_atmrange},
     {0, "ATMEXPLOSIVE <weapnum>", "Sets weapon to and from High Explosive Mode", mech_atmexplosive},
@@ -574,7 +574,7 @@ CommandsStruct mechcommands[] = {
     {1, "CLAW [R | L |B] [<TARGET-ID>]", "Claws a target", mech_claw},
     {1, "CLUB [<TARGET-ID>]", "Clubs a target with a tree", mech_club},
     {1, "MACE [<TARGET-ID>]", "Maces your target", mech_mace},
-    {1, "SAW [<TARGET-ID>]", "Saws a target with a Dual Saw", mech_saw},    
+    {1, "SAW [<TARGET-ID>]", "Saws a target with a Dual Saw", mech_saw},
     {1, "KICK [R | L] [<TARGET-ID>]", "Kicks a target", mech_kick},
     {1, "TRIP [R | L] [<TARGET-ID>]", "Trips a target mech", mech_trip},
     {1, "PUNCH [R | L | B] [<TARGET-ID>]", "Punches a target", mech_punch},
@@ -946,12 +946,6 @@ CommandsStruct sscommands[] = {
 #undef HEADER
 
 
-#endif
-
-/* Something about [new] Linux gcc is braindead.. I just don't know
-   what, but this allows the code to link [bleah] */
-#ifdef memcpy
-#undef memcpy
 #endif
 
 void send_channel(char *, const char *, ...);

--- a/btech/src/include/macros.h
+++ b/btech/src/include/macros.h
@@ -51,7 +51,7 @@ if (a) { safe_tprintf_str(buff, bufc, b); return; }
 
 /* Dice-rolling function used everywhere converted to a macro */
 /* And now converted back to a function.  */
-extern inline long int Number(long int, long int);
+extern long int Number(long int, long int);
 
 #define skipws(name)     while (name && *name && isspace(*name)) name++
 #define readint(to,from) \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -3,7 +3,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/include \
 	-I$(top_srcdir)/btech/src/include -I$(top_srcdir)/btech/src/btech
 
 # TODO: Fiddle with the default compiler options.
-#CFLAGS = -Wall -Wno-unused
+AM_CFLAGS = -Werror -Wfatal-errors
 #ifdef DEBUG
 #CFLAGS += -g3
 #CPPFLAGS += -DDEBUG

--- a/src/comsys.c
+++ b/src/comsys.c
@@ -1,5 +1,5 @@
 /*
- * comsys.c 
+ * comsys.c
  */
 
 #include <ctype.h>
@@ -27,15 +27,13 @@ static void do_show_com(chmsg *);
 static void do_comlast(dbref, struct channel *);
 static void do_comsend(struct channel *, char *);
 static void do_comprintf(struct channel *, char *, ...);
-extern void do_joinchannel(dbref, struct channel *);
 static void do_leavechannel(dbref, struct channel *);
 static void do_comwho(dbref, struct channel *);
 static void do_setnewtitle(dbref, struct channel *, char *);
-extern void sort_users(struct channel *);
 static int do_test_access(dbref, long, struct channel *);
 
 /*
- * This is the hash table for channel names 
+ * This is the hash table for channel names
  */
 
 void init_chantab(void)
@@ -394,7 +392,7 @@ static void do_comprintf(struct channel *ch, char *messfmt, ...)
 	myfifo_push(&ch->last_messages, c);
 }
 
-extern void do_joinchannel(dbref player, struct channel *ch)
+void do_joinchannel(dbref player, struct channel *ch)
 {
 	struct comuser *user;
 	int i;
@@ -407,7 +405,7 @@ extern void do_joinchannel(dbref player, struct channel *ch)
 			ch->max_users += 10;
 			ch->users = realloc(ch->users, sizeof(struct comuser *) *
 								ch->max_users);
-			memset(ch->users+(ch->num_users-1), 0, 
+			memset(ch->users+(ch->num_users-1), 0,
 				sizeof(struct comuser *)*(ch->max_users-ch->num_users));
 		}
 		user = (struct comuser *) malloc(sizeof(struct comuser));
@@ -980,7 +978,7 @@ void do_allcom(dbref player, dbref cause, int key, char *arg1)
 
 }
 
-extern void sort_users(struct channel *ch)
+void sort_users(struct channel *ch)
 {
 	int i;
 	int nu;
@@ -1325,7 +1323,7 @@ static int do_test_access(dbref player, long access, struct channel *chan)
 		flag_value *= CHANNEL_OBJ_MULT;
 	flag_value &= 0xFF;			/*
 								 * Mask out CHANNEL_PUBLIC and CHANNEL_LOUD
-								 * just to be paranoid. 
+								 * just to be paranoid.
 								 */
 
 	return (((long) chan->type & flag_value));
@@ -1533,7 +1531,7 @@ void do_chboot(dbref player, dbref cause, int key, char *channel,
 
 	/*
 	 * * I sure hope it's not going to be that *
-	 * *  * *  * *  * * long.  
+	 * *  * *  * *  * * long.
 	 */
 
 	if(!mudconf.have_comsys) {
@@ -1563,7 +1561,7 @@ void do_chboot(dbref player, dbref cause, int key, char *channel,
 		return;
 	}
 	/*
-	 * We should be in the clear now. :) 
+	 * We should be in the clear now. :)
 	 */
 	do_comprintf(ch, "[%s] %s boots %s off the channel.", ch->name,
                unparse_object_numonly(player), unparse_object_numonly(thing));

--- a/src/comsys.h
+++ b/src/comsys.h
@@ -53,6 +53,8 @@ int max_channels;
 
 /* some extern functions. */
 extern int In_IC_Loc(dbref player);
+extern void do_joinchannel(dbref, struct channel *);
+extern void sort_users(struct channel *);
 
 #define CHANNEL_JOIN		0x001
 #define CHANNEL_TRANSMIT	0x002

--- a/src/conf.c
+++ b/src/conf.c
@@ -155,7 +155,7 @@ void cf_init(void)
 	mudconf.btech_standcareful = 1;
 	mudconf.btech_maxtechtime = 600;
 	mudconf.btech_blzmapmode = 0;
-        mudconf.btech_extended_piloting = 1;
+    mudconf.btech_extended_piloting = 1;
 	mudconf.btech_extended_gunnery = 1;
 	mudconf.btech_xploss_for_mw = 1;
 	mudconf.btech_variable_techtime = 0;
@@ -169,7 +169,7 @@ void cf_init(void)
 #endif
 #ifdef HUDINFO_SUPPORT
 	mudconf.hudinfo_show_mapinfo = 0;
-	mudconf.hudinfo_enabled;
+	mudconf.hudinfo_enabled = 0;
 #endif
 	mudconf.registeredonly = 0;
 	mudconf.namechange_days = 60;
@@ -1181,7 +1181,7 @@ CONF conftable[] = {
 	{(char *) "btech_glancing_blows", cf_int, CA_GOD, &mudconf.btech_glancing_blows, 0},
 	{(char *) "btech_inferno_penalty",
 	 cf_int, CA_GOD, &mudconf.btech_inferno_penalty, 0},
-	{(char *) "btech_blzmapmode", 
+	{(char *) "btech_blzmapmode",
 	 cf_int, CA_GOD, &mudconf.btech_blzmapmode, 0},
 	{(char *) "btech_extended_piloting",
 	 cf_int, CA_GOD, &mudconf.btech_extended_piloting, 0},
@@ -1690,8 +1690,8 @@ int cf_set(char *cp, char *ap, dbref player)
             StringCopy(buff, ap);
 			i = tp->interpreter(tp->loc, ap, tp->extra, player, cp);
 			if(!mudstate.initializing) {
-                log_error(LOG_CONFIGMODS, "CFG", "UPDAT", 
-                "%s entered config directive: %s with args '%s'. Status: %s%s%s%s", 
+                log_error(LOG_CONFIGMODS, "CFG", "UPDAT",
+                "%s entered config directive: %s with args '%s'. Status: %s%s%s%s",
                 Name(player), cp, buff, (i==0?"Success":(i==1?"Partial success":(i==-1?"Failure":"Strange"))));
 
 			}

--- a/src/db.h
+++ b/src/db.h
@@ -217,7 +217,9 @@ extern dbref db_read(FILE *, int *, int *, int *);
 extern dbref db_write(FILE *, int, int);
 extern void destroy_thing(dbref);
 extern void destroy_exit(dbref);
+extern int load_restart_db_xdr(void);
 extern void load_restart_db(void);
+extern void dump_restart_db_xdr(void);
 extern void dump_database_internal(int);
 
 #define	DOLIST(thing,list) \

--- a/src/db_xdr.c
+++ b/src/db_xdr.c
@@ -130,10 +130,10 @@ void mmdb_db_write(char *filename)
 	/* START COMMAC */
 	mmdb_write_uint32(mmdb, COMMAC_MAGIC);
 	mmdb_write_uint32(mmdb, COMMAC_VERSION);
-	
+
 	purge_commac();
 	np = 0;
-	
+
 	for(i = 0; i < NUM_COMMAC; i++) {
 		c = commac_table[i];
 		while (c) {
@@ -182,7 +182,7 @@ void mmdb_db_write(char *filename)
 			myfifo_trav_r_xdr(&ch->last_messages,mmdb,do_save_com_xdr);
 
 		player_users = 0;
-		for(j = 0; j < ch->num_users; j++) 
+		for(j = 0; j < ch->num_users; j++)
 			if(isPlayer(ch->users[j]->who) || isRobot(ch->users[j]->who))
 				player_users++;
 
@@ -300,7 +300,7 @@ int mmdb_db_read(char *filename)
 		}
 	}
 	load_player_names();
-	
+
 	magic = mmdb_read_uint32(mmdb);
 	dassert(magic == COMMAC_MAGIC);
 	version = mmdb_read_uint32(mmdb);
@@ -321,7 +321,7 @@ int mmdb_db_read(char *filename)
 		if(c->maxchannels > 0) {
 			c->alias = (char *) malloc(c->maxchannels * 6);
 			c->channels = (char **) malloc(sizeof(char *) * c->maxchannels);
-			
+
 			for(j = 0; j < c->numchannels; j++) {
 				len = mmdb_read_uint32(mmdb);
 				mmdb_read(mmdb, buffer, len);
@@ -330,7 +330,7 @@ int mmdb_db_read(char *filename)
 
 				len = mmdb_read_uint32(mmdb);
 				mmdb_read(mmdb, buffer, len);
-	
+
 				c->channels[j] = (char *) malloc(strlen(buffer) + 1);
 				StringCopy(c->channels[j],buffer);
 
@@ -351,14 +351,14 @@ int mmdb_db_read(char *filename)
 
 	for( i = 0; i < num_channels; i++) {
 		ch = (struct channel *) malloc(sizeof(struct channel));
-		
-	
+
+
 		len = mmdb_read_uint32(mmdb);
 		mmdb_read(mmdb,buffer,len);
 
 		strncpy(ch->name, buffer, len);
 		ch->on_users = NULL;
-		
+
 		hashadd(ch->name, (int *) ch, &mudstate.channel_htab);
 		ch->type = mmdb_read_uint32(mmdb);
 		ch->charge = mmdb_read_uint32(mmdb);
@@ -368,7 +368,7 @@ int mmdb_db_read(char *filename)
 		ch->chan_obj = mmdb_read_uint32(mmdb);
 		k = mmdb_read_uint32(mmdb);
 		ch->last_messages = NULL;
-		
+
 		if (k > 0) {
 			for(j = 0; j < k; j++) {
 				chmsg *c;
@@ -379,14 +379,14 @@ int mmdb_db_read(char *filename)
 				c->msg = strdup(buffer);
 				myfifo_push(&ch->last_messages, c);
 			}
-			
+
 		}
 		ch->num_users = mmdb_read_uint32(mmdb);
 		ch->max_users = ch->num_users;
 
 		if(ch->num_users > 0) {
 			ch->users = (struct comuser **) calloc(ch->max_users, sizeof(struct comuser *));
-			
+
 			for(j =0; j < ch->num_users; j++) {
 				user = (struct comuser *) malloc(sizeof(struct comuser));
 
@@ -416,7 +416,7 @@ int mmdb_db_read(char *filename)
 			sort_users(ch);
 		} else
 			ch->users = NULL;
-	}		
+	}
 
 
 	/* END COMSYS SECTION */
@@ -424,7 +424,7 @@ int mmdb_db_read(char *filename)
 	/* BEGIN MACRO SECTION */
 	nummacros = mmdb_read_uint32(mmdb);
 	maxmacros = nummacros;
-	
+
 	if(maxmacros > 0)
 		macros = (struct macros **) malloc(sizeof(struct macros *) * nummacros);
 	else

--- a/src/dllist.c
+++ b/src/dllist.c
@@ -19,7 +19,7 @@ dllist *dllist_create_list()
         return NULL;
     }
 
-    memset(temp, 0, sizeof(temp));
+    memset(temp, 0, sizeof(dllist));
     temp->head = NULL;
     temp->tail = NULL;
     temp->size = 0;
@@ -290,7 +290,7 @@ dllist_node *dllist_head(dllist * dllist)
 /* Get Tail Node */
 dllist_node *dllist_tail(dllist * dllist)
 {
-    
+
     if (!dllist)
         return NULL;
 

--- a/src/funceval.c
+++ b/src/funceval.c
@@ -641,11 +641,13 @@ static char *crypt_code(char *code, char *text, int type)
 	char *p, *q, *r;
 
 	if(!text && !*text)
-		return ((char *) "");
+		return (char *) "";
+	if(!code || !*code)
+		return text;
 	StringCopy(codebuff, crunch_code(code));
-	if(!code || !*code || !codebuff || !*codebuff)
-		return (text);
-	StringCopy(textbuff, "");
+	if (!*codebuff)
+		return text;
+	textbuff[0] = '\0';
 
 	p = text;
 	q = codebuff;

--- a/src/game.c
+++ b/src/game.c
@@ -1282,11 +1282,11 @@ int real_main(int argc, char *argv[])
 
 	mindb = 0;					/* Are we creating a new db? */
 	corrupt = 0;				/* Database isn't corrupted. */
-    memset(&mudstate, 0, sizeof(mudstate));
+  memset(&mudstate, 0, sizeof(mudstate));
 	time(&mudstate.start_time);
 	time(&mudstate.restart_time);
 	mudstate.executable_path = strdup(argv[0]);
-    mudstate.db_top = -1;
+  mudstate.db_top = -1;
 	tcache_init();
 	pcache_init();
 	cf_init();

--- a/src/interface.h
+++ b/src/interface.h
@@ -138,7 +138,7 @@ extern void raw_notify_raw(dbref, const char *, char *);
 extern void raw_notify_newline(dbref);
 extern void hudinfo_notify(DESC *, const char *, const char *, const char *);
 extern void clearstrings(DESC *);
-extern void queue_write(DESC *, char *, int);
+extern void queue_write(DESC *, const char *, int);
 extern void queue_string(DESC *, const char *);
 extern void freeqs(DESC *);
 extern void welcome_user(DESC *);

--- a/src/log.c
+++ b/src/log.c
@@ -1,5 +1,5 @@
 /*
- * log.c - logging routines 
+ * log.c - logging routines
  */
 
 #include "copyright.h"
@@ -58,7 +58,7 @@ char *strip_ansi_r(char *dest, const char *raw, size_t n)
 	while (p && *p && ((q - dest) < n)) {
 		if(*p == ESC_CHAR) {
 			/*
-			 * Start of ANSI code. Skip to end. 
+			 * Start of ANSI code. Skip to end.
 			 */
 			while (*p && !isalpha(*p))
 				p++;
@@ -74,17 +74,17 @@ char *strip_ansi_r(char *dest, const char *raw, size_t n)
 char *normal_to_white_r(char *dest, const char *raw, size_t n) {
     char *p = (char *) raw;
 	char *q = dest;
-    
+
 	while (p && *p && ((q - dest) < n)) {
 		if(*p == ESC_CHAR) {
 			/*
-			 * Start of ANSI code. 
+			 * Start of ANSI code.
 			 */
 			*q++ = *p++;		/*
-								 * ESC CHAR 
+								 * ESC CHAR
 								 */
 			*q++ = *p++;		/*
-								 * [ character. 
+								 * [ character.
 								 */
 			if(*p == '0') {
                 if((q - dest + 7) < n) {
@@ -115,7 +115,7 @@ int start_log(const char *primary, const char *secondary)
 	case 2:
 
 		/*
-		 * Format the timestamp 
+		 * Format the timestamp
 		 */
 
 		if((mudconf.log_info & LOGOPT_TIMESTAMP) != 0) {
@@ -129,7 +129,7 @@ int start_log(const char *primary, const char *secondary)
 		}
 
 		/*
-		 * Write the header to the log 
+		 * Write the header to the log
 		 */
 
 		if(secondary && *secondary)
@@ -139,7 +139,7 @@ int start_log(const char *primary, const char *secondary)
 			fprintf(stderr, "%s%s %-9s: ", mudstate.buffer,
 					mudconf.mud_name, primary);
 		/*
-		 * If a recursive call, log it and return indicating no log 
+		 * If a recursive call, log it and return indicating no log
 		 */
 
 		if(mudstate.logging == 1)
@@ -207,7 +207,7 @@ void log_error(int key, char *primary, char *secondary, char *format, ...)
 				tm.tm_hour, tm.tm_min, tm.tm_sec);
 	}
 
-	if(secondary && &secondary) {
+	if (secondary) {
 		fprintf(stderr, "%s%s %3s/%-5s: ", mudstate.buffer,
 				mudconf.mud_name, primary, secondary);
 	} else {

--- a/src/macro.c
+++ b/src/macro.c
@@ -1,5 +1,5 @@
 /*
- * macro.c - ported from BattleTech 3056 MUSE 
+ * macro.c - ported from BattleTech 3056 MUSE
  */
 
 #include "copyright.h"
@@ -78,10 +78,10 @@ int do_macro(dbref player, char *in, char **out)
 		free_lbuf(old);
 		return 2;				/*
 								 * return any value > 1, and command * * *
-								 * processing will 
+								 * processing will
 								 */
 	}							/*
-								 * continue 
+								 * continue
 								 */
 }
 
@@ -395,7 +395,7 @@ void do_chown_macro(dbref player, char *cmd)
 	free_lbuf(unparse);
 }
 
-extern void clear_macro_set(int set)
+void clear_macro_set(int set)
 {
 	struct macros *m;
 	struct commac *c;
@@ -588,7 +588,7 @@ char *do_process_macro(dbref player, char *in, char *s)
 	buff = alloc_lbuf("do_process_macro");
 	cmd = in + 1;
 	buff[0] = '\0';				/*
-								 * End the string 
+								 * End the string
 								 */
 	for(i = 0; i < 5; i++) {
 		if(GMac(c->macros[i])) {
@@ -774,7 +774,7 @@ int can_read_macros(dbref player, struct macros *m)
 		return m->status & MACRO_R;
 }
 
-#define TST(cmd,msg) if (cmd) { fprintf(stderr, msg); exit(1); }
+#define TST(cmd,msg) if (cmd) { fprintf(stderr, "%s", msg); exit(1); }
 
 void load_macros(FILE * fp)
 {

--- a/src/macro.h
+++ b/src/macro.h
@@ -48,6 +48,7 @@ int can_read_macros();
 void do_sort_macro_set();
 void save_macros();
 void load_macros();
+void clear_macro_set();
 
 int do_macro();
 void do_add_macro();

--- a/src/mail.c
+++ b/src/mail.c
@@ -1,10 +1,10 @@
 /*
- * mail.c 
+ * mail.c
  *
  * This code was taken from Kalkin's DarkZone code, which was
  * originally taken from PennMUSH 1.50 p10, and has been heavily modified
  * since being included in MUX.
- * 
+ *
  */
 
 #include "copyright.h"
@@ -68,7 +68,7 @@ int ma_top = 0;
 struct malias **malias;
 
 /*
- * Handling functions for the database of mail messages. 
+ * Handling functions for the database of mail messages.
  */
 
 /*
@@ -162,7 +162,7 @@ static int add_mail_message(dbref player, char *message)
 		mail_db_grow(1);
 	}
 	/*
-	 * Add an extra bit of protection here 
+	 * Add an extra bit of protection here
 	 */
 	while (mudstate.mail_list[mudstate.mail_freelist].message != NULL) {
 		make_mail_freelist();
@@ -191,7 +191,7 @@ static int add_mail_message(dbref player, char *message)
 }
 
 /*
- * add_mail_message_nosig - used for reading in old style messages from disk 
+ * add_mail_message_nosig - used for reading in old style messages from disk
  */
 
 static int add_mail_message_nosig(char *message)
@@ -219,7 +219,7 @@ static void new_mail_message(char *message, int number)
 }
 
 /*
- * add_count - increments the reference count for any particular message 
+ * add_count - increments the reference count for any particular message
  */
 
 static INLINE void add_count(int number)
@@ -265,7 +265,7 @@ INLINE char *get_mail_message(int number)
 /*-------------------------------------------------------------------------*
  *   User mail functions (these are called from game.c)
  *
- * do_mail - cases 
+ * do_mail - cases
  * do_mail_read - read messages
  * do_mail_list - list messages
  * do_mail_flags - tagging, untagging, clearing, unclearing of messages
@@ -279,7 +279,7 @@ INLINE char *get_mail_message(int number)
 extern char *upcasestr(char *);
 
 /*
- * Change or rename a folder 
+ * Change or rename a folder
  */
 void do_mail_change_folder(dbref player, char *fld, char *newname)
 {
@@ -288,7 +288,7 @@ void do_mail_change_folder(dbref player, char *fld, char *newname)
 
 	if(!fld || !*fld) {
 		/*
-		 * Check mail in all folders 
+		 * Check mail in all folders
 		 */
 		for(pfld = MAX_FOLDERS; pfld >= 0; pfld--)
 			check_mail(player, pfld, 1);
@@ -306,7 +306,7 @@ void do_mail_change_folder(dbref player, char *fld, char *newname)
 	}
 	if(newname && *newname) {
 		/*
-		 * We're changing a folder name here 
+		 * We're changing a folder name here
 		 */
 		if(strlen(newname) > FOLDER_NAME_LEN) {
 			notify(player, "MAIL: Folder name too long");
@@ -324,7 +324,7 @@ void do_mail_change_folder(dbref player, char *fld, char *newname)
 					  newname);
 	} else {
 		/*
-		 * Set a new folder 
+		 * Set a new folder
 		 */
 		set_player_folder(player, pfld);
 		notify_printf(player, "MAIL: Current folder set to %d [%s].",
@@ -410,14 +410,14 @@ static void do_mail_flags(dbref player, char *msglist, mail_flag flag,
 
 	if(!j) {
 		/*
-		 * ran off the end of the list without finding anything 
+		 * ran off the end of the list without finding anything
 		 */
 		notify(player, "MAIL: You don't have any matching messages!");
 	}
 }
 
 /*
- * Change a message's folder 
+ * Change a message's folder
  */
 
 void do_mail_file(dbref player, char *msglist, char *folder)
@@ -442,7 +442,7 @@ void do_mail_file(dbref player, char *msglist, char *folder)
 			if(mail_match(mp, ms, i)) {
 				j++;
 				mp->read &= M_FMASK;	/*
-										 * Clear the folder 
+										 * Clear the folder
 										 */
 				mp->read |= FolderBit(foldernum);
 				notify_printf(player, "MAIL: Msg %d filed in folder %d",
@@ -453,14 +453,14 @@ void do_mail_file(dbref player, char *msglist, char *folder)
 
 	if(!j) {
 		/*
-		 * ran off the end of the list without finding anything 
+		 * ran off the end of the list without finding anything
 		 */
 		notify(player, "MAIL: You don't have any matching messages!");
 	}
 }
 
 /*
- * print a mail message(s) 
+ * print a mail message(s)
  */
 
 void do_mail_read(dbref player, char *msglist)
@@ -483,7 +483,7 @@ void do_mail_read(dbref player, char *msglist)
 			i++;
 			if(mail_match(mp, ms, i)) {
 				/*
-				 * Read it 
+				 * Read it
 				 */
 				j++;
 				buff = alloc_lbuf("do_mail_read");
@@ -507,11 +507,11 @@ void do_mail_read(dbref player, char *msglist)
 				free_lbuf(buff);
 				if(Unread(mp))
 					mp->read |= M_ISREAD;	/*
-											 * mark * * * 
-											 * message as 
-											 * 
+											 * mark * * *
+											 * message as
+											 *
 											 * *  * *  *
-											 * * * read 
+											 * * * read
 											 */
 			}
 		}
@@ -519,7 +519,7 @@ void do_mail_read(dbref player, char *msglist)
 
 	if(!j) {
 		/*
-		 * ran off the end of the list without finding anything 
+		 * ran off the end of the list without finding anything
 		 */
 		notify(player, "MAIL: You don't have that many matching messages!");
 	}
@@ -580,7 +580,7 @@ void do_mail_retract(dbref player, char *name, char *msglist)
 
 	if(!j) {
 		/*
-		 * ran off the end of the list without finding anything 
+		 * ran off the end of the list without finding anything
 		 */
 		notify(player, "MAIL: No matching messages.");
 	}
@@ -609,7 +609,7 @@ void do_mail_review(dbref player, char *name, char *msglist)
 			if(mp->from == player) {
 				i++;
 				/*
-				 * list it 
+				 * list it
 				 */
 				notify_printf(player,
 							  "[%s] %-3d (%4d) From: %-*s Sub: %.25s",
@@ -634,7 +634,7 @@ void do_mail_review(dbref player, char *name, char *msglist)
 				i++;
 				if(mail_match(mp, ms, i)) {
 					/*
-					 * Read it 
+					 * Read it
 					 */
 					j++;
 					status = status_string(mp);
@@ -666,7 +666,7 @@ void do_mail_review(dbref player, char *name, char *msglist)
 		if(!j) {
 			/*
 			 * ran off the end of the list without finding * * *
-			 * anything 
+			 * anything
 			 */
 			notify(player,
 				   "MAIL: You don't have that many matching messages!");
@@ -697,7 +697,7 @@ void do_mail_list(dbref player, char *msglist, int sub)
 			i++;
 			if(mail_match(mp, ms, i)) {
 				/*
-				 * list it 
+				 * list it
 				 */
 
 				time = mail_list_time(mp->time);
@@ -738,10 +738,10 @@ static char *mail_list_time(const char *the_time)
 		return new;
 	}
 	/*
-	 * Format of the_time is: day mon dd hh:mm:ss yyyy 
+	 * Format of the_time is: day mon dd hh:mm:ss yyyy
 	 */
 	/*
-	 * Chop out :ss 
+	 * Chop out :ss
 	 */
 	for(i = 0; i < 16; i++) {
 		if(*p)
@@ -767,16 +767,16 @@ void do_mail_purge(dbref player)
 	struct mail *mp, *nextp;
 
 	/*
-	 * Go through player's mail, and remove anything marked cleared 
+	 * Go through player's mail, and remove anything marked cleared
 	 */
 	for(mp = (struct mail *) nhashfind((int) player, &mudstate.mail_htab);
 		mp; mp = nextp) {
 		if(Cleared(mp)) {
 			/*
-			 * Delete this one 
+			 * Delete this one
 			 */
 			/*
-			 * head and tail of the list are special 
+			 * head and tail of the list are special
 			 */
 			if(mp->prev == NULL)
 				nhashrepl((int) player, (int *) mp->next,
@@ -785,7 +785,7 @@ void do_mail_purge(dbref player)
 				mp->prev->next = NULL;
 
 			/*
-			 * relink the list 
+			 * relink the list
 			 */
 			if(mp->prev != NULL)
 				mp->prev->next = mp->next;
@@ -793,16 +793,16 @@ void do_mail_purge(dbref player)
 				mp->next->prev = mp->prev;
 
 			/*
-			 * save the pointer 
+			 * save the pointer
 			 */
 			nextp = mp->next;
 
 			/* Clear it. its the last message in the list */
-			if(mp->prev == NULL && mp->next == NULL) 
+			if(mp->prev == NULL && mp->next == NULL)
 				nhashdelete((int) player, &mudstate.mail_htab);
-				
+
 			/*
-			 * then wipe 
+			 * then wipe
 			 */
 			free((char *) mp->subject);
 			delete_mail_message(mp->number);
@@ -878,7 +878,7 @@ struct mail *mail_fetch(dbref player, int num)
 
 /*
  * returns count of read, unread, & cleared messages as rcount, ucount,
- * * ccount 
+ * * ccount
  */
 
 void count_mail(dbref player, int folder, int *rcount,
@@ -939,11 +939,11 @@ static void send_mail(dbref player, dbref target, const char *tolist,
 	tt = time(NULL);
 	StringCopy(tbuf1, ctime(&tt));
 	tbuf1[strlen(tbuf1) - 1] = '\0';	/*
-										 * whack the newline 
+										 * whack the newline
 										 */
 
 	/*
-	 * initialize the appropriate fields 
+	 * initialize the appropriate fields
 	 */
 	newp = (struct mail *) malloc(sizeof(struct mail));
 
@@ -957,11 +957,11 @@ static void send_mail(dbref player, dbref target, const char *tolist,
 	newp->time = (char *) strdup(tbuf1);
 	newp->subject = (char *) strdup(subject);
 	newp->read = flags & M_FMASK;	/*
-									 * Send to folder 0 
+									 * Send to folder 0
 									 */
 
 	/*
-	 * if this is the first message, it is the head and the tail 
+	 * if this is the first message, it is the head and the tail
 	 */
 	if(!nhashfind((int) target, &mudstate.mail_htab)) {
 		nhashadd((int) target, (int *) newp, &mudstate.mail_htab);
@@ -978,7 +978,7 @@ static void send_mail(dbref player, dbref target, const char *tolist,
 	}
 
 	/*
-	 * notify people 
+	 * notify people
 	 */
 	if(!silent)
 		notify_printf(player, "MAIL: You sent your message to %s.",
@@ -1002,7 +1002,7 @@ void do_mail_nuke(dbref player)
 		return;
 	}
 	/*
-	 * walk the list 
+	 * walk the list
 	 */
 	MAIL_ITER_SAFE(mp, thing, nextp) {
 		nextp = mp->next;
@@ -1059,10 +1059,10 @@ void do_mail_debug(dbref player, char *action, char *victim)
 			if(!Good_obj(mp->to) || (Typeof(mp->to) != TYPE_PLAYER)) {
 				notify_printf(player, "Fixing mail for #%d.", mp->to);
 				/*
-				 * Delete this one 
+				 * Delete this one
 				 */
 				/*
-				 * head and tail of the list are * special 
+				 * head and tail of the list are * special
 				 */
 				if(mp->prev == NULL)
 					nhashrepl((int) player, (int *) mp->next,
@@ -1070,18 +1070,18 @@ void do_mail_debug(dbref player, char *action, char *victim)
 				else if(mp->next == NULL)
 					mp->prev->next = NULL;
 				/*
-				 * relink the list 
+				 * relink the list
 				 */
 				if(mp->prev != NULL)
 					mp->prev->next = mp->next;
 				if(mp->next != NULL)
 					mp->next->prev = mp->prev;
 				/*
-				 * save the pointer 
+				 * save the pointer
 				 */
 				nextp = mp->next;
 				/*
-				 * then wipe 
+				 * then wipe
 				 */
 				free((char *) mp->subject);
 				delete_mail_message(mp->number);
@@ -1108,7 +1108,7 @@ void do_mail_stats(dbref player, char *name, int full)
 	fc = fr = fu = tc = tr = tu = cchars = fchars = tchars = count = 0;
 
 	/*
-	 * find player 
+	 * find player
 	 */
 
 	if((*name == '\0') || !name) {
@@ -1140,7 +1140,7 @@ void do_mail_stats(dbref player, char *name, int full)
 		return;
 	}
 	/*
-	 * this comand is computationally expensive 
+	 * this comand is computationally expensive
 	 */
 
 	if(!payfor(player, mudconf.searchcost)) {
@@ -1151,7 +1151,7 @@ void do_mail_stats(dbref player, char *name, int full)
 		return;
 	}
 	if(target == AMBIGUOUS) {	/*
-								 * stats for all 
+								 * stats for all
 								 */
 		if(full == 0) {
 			MAIL_ITER_ALL(mp, thing) {
@@ -1200,12 +1200,12 @@ void do_mail_stats(dbref player, char *name, int full)
 		}
 	}
 	/*
-	 * individual stats 
+	 * individual stats
 	 */
 
 	if(full == 0) {
 		/*
-		 * just count number of messages 
+		 * just count number of messages
 		 */
 		MAIL_ITER_ALL(mp, thing) {
 			if(mp->from == target)
@@ -1218,7 +1218,7 @@ void do_mail_stats(dbref player, char *name, int full)
 		return;
 	}
 	/*
-	 * more detailed message count 
+	 * more detailed message count
 	 */
 	MAIL_ITER_ALL(mp, thing) {
 		if(mp->from == target) {
@@ -1286,20 +1286,20 @@ void do_mail_stub(dbref player, char *arg1, char *arg2)
 			return;
 		}
 		/*
-		 * just the "@mail" command 
+		 * just the "@mail" command
 		 */
 		do_mail_list(player, arg1, 1);
 		return;
 	}
 	/*
-	 * purge a player's mailbox 
+	 * purge a player's mailbox
 	 */
 	if(!strcasecmp(arg1, "purge")) {
 		do_mail_purge(player);
 		return;
 	}
 	/*
-	 * clear message 
+	 * clear message
 	 */
 	if(!strcasecmp(arg1, "clear")) {
 		do_mail_clear(player, arg2);
@@ -1311,13 +1311,13 @@ void do_mail_stub(dbref player, char *arg1, char *arg2)
 	}
 	if(arg2 && *arg2) {
 		/*
-		 * Sending mail 
+		 * Sending mail
 		 */
 		do_expmail_start(player, arg1, arg2);
 		return;
 	} else {
 		/*
-		 * Must be reading or listing mail - no arg2 
+		 * Must be reading or listing mail - no arg2
 		 */
 		if(isdigit(*arg1) && !index(arg1, '-'))
 			do_mail_read(player, arg1);
@@ -1429,7 +1429,7 @@ int dump_mail(FILE * fp)
 	int count = 0, i;
 
 	/*
-	 * Write out version number 
+	 * Write out version number
 	 */
 	fprintf(fp, "+V5\n");
 	putref(fp, mudstate.mail_db_top);
@@ -1454,7 +1454,7 @@ int dump_mail(FILE * fp)
 	fprintf(fp, "*** END OF DUMP ***\n");
 
 	/*
-	 * Add the db of mail messages 
+	 * Add the db of mail messages
 	 */
 	for(i = 0; i < mudstate.mail_db_top; i++) {
 		if(mudstate.mail_list[i].count > 0) {
@@ -1484,7 +1484,7 @@ int load_mail(FILE * fp)
 	struct mail *mp, *mptr;
 
 	/*
-	 * Read the version number 
+	 * Read the version number
 	 */
 	fgets(nbuf1, sizeof(nbuf1), fp);
 
@@ -1509,7 +1509,7 @@ int load_mail(FILE * fp)
 		fgets(nbuf1, sizeof(nbuf1), fp);	/*
 											 * Toss away the * *
 											 * * number of
-											 * messages  *  * *  
+											 * messages  *  * *
 											 */
 	if(read_newdb) {
 		mail_top = getref(fp);
@@ -1617,7 +1617,7 @@ static int get_folder_number(dbref player, char *name)
 	p = res;
 	while (!isspace(*p))
 		p++;
-	p = '\0';
+	*p = '\0';
 	free_lbuf(atrstr);
 	free_lbuf(str);
 	free_lbuf(pat);
@@ -1633,7 +1633,7 @@ static char *get_folder_name(dbref player, int fld)
 	long flags; int len;
 
 	/*
-	 * Get the name of the folder, or "nameless" 
+	 * Get the name of the folder, or "nameless"
 	 */
 	pat = alloc_lbuf("get_folder_name");
 	sprintf(pat, "%d:", fld);
@@ -1670,10 +1670,10 @@ void add_folder_name(dbref player, int fld, char *name)
 	long aflags;
 
 	/*
-	 * Muck with the player's MAILFOLDERS attrib to add a string of the * 
-	 * 
+	 * Muck with the player's MAILFOLDERS attrib to add a string of the *
+	 *
 	 * *  * * form: number:name:number to it, replacing any such string
-	 * with a  *  * * * matching number. 
+	 * with a  *  * * * matching number.
 	 */
 
 	new = alloc_lbuf("add_folder_name.new");
@@ -1684,7 +1684,7 @@ void add_folder_name(dbref player, int fld, char *name)
 	sprintf(new, "%d:%s:%d ", fld, upcasestr(name), fld);
 	sprintf(pat, "%d:", fld);
 	/*
-	 * get the attrib and the old string, if any 
+	 * get the attrib and the old string, if any
 	 */
 	old = NULL;
 
@@ -1708,7 +1708,7 @@ void add_folder_name(dbref player, int fld, char *name)
 		*r = '\0';
 	}
 	/*
-	 * put the attrib back 
+	 * put the attrib back
 	 */
 	atr_add(player, A_MAILFOLDERS, res, player,
 			AF_MDARK | AF_WIZARD | AF_NOPROG | AF_LOCK);
@@ -1723,9 +1723,9 @@ void add_folder_name(dbref player, int fld, char *name)
 static int player_folder(dbref player)
 {
 	/*
-	 * Return the player's current folder number. If they don't have one, 
-	 * 
-	 * *  * *  * * set * it to 0 
+	 * Return the player's current folder number. If they don't have one,
+	 *
+	 * *  * *  * * set * it to 0
 	 */
 	long flags; int number;
 	char *atrstr;
@@ -1744,7 +1744,7 @@ static int player_folder(dbref player)
 void set_player_folder(dbref player, int fnum)
 {
 	/*
-	 * Set a player's folder to fnum 
+	 * Set a player's folder to fnum
 	 */
 	ATTR *a;
 	char *tbuf1;
@@ -1755,7 +1755,7 @@ void set_player_folder(dbref player, int fnum)
 	if(a)
 		atr_add(player, A_MAILCURF, tbuf1, GOD, a->flags);
 	else {						/*
-								 * Shouldn't happen, but... 
+								 * Shouldn't happen, but...
 								 */
 		atr_add(player, A_MAILCURF, tbuf1, GOD,
 				AF_ODARK | AF_WIZARD | AF_NOPROG | AF_LOCK);
@@ -1769,8 +1769,8 @@ static int parse_folder(dbref player, char *folder_string)
 
 	/*
 	 * Given a string, return a folder #, or -1 The string is just a * *
-	 * * number, * for now. Later, this will be where named folders are * 
-	 * *  * handled 
+	 * * number, * for now. Later, this will be where named folders are *
+	 * *  * handled
 	 */
 	if(!folder_string || !*folder_string)
 		return -1;
@@ -1782,7 +1782,7 @@ static int parse_folder(dbref player, char *folder_string)
 			return fnum;
 	}
 	/*
-	 * Handle named folders here 
+	 * Handle named folders here
 	 */
 	return get_folder_number(player, folder_string);
 }
@@ -1795,7 +1795,7 @@ static int mail_match(struct mail *mp, struct mail_selector ms, int num)
 	mail_flag mpflag;
 
 	/*
-	 * Does a piece of mail match the mail_selector? 
+	 * Does a piece of mail match the mail_selector?
 	 */
 	if(ms.low && num < ms.low)
 		return 0;
@@ -1808,15 +1808,15 @@ static int mail_match(struct mail *mp, struct mail_selector ms, int num)
 		return 0;
 	if(ms.days != -1) {
 		/*
-		 * Get the time now, subtract mp->time, and compare the * * * 
-		 * results with * ms.days (in manner of ms.day_comp) 
+		 * Get the time now, subtract mp->time, and compare the * * *
+		 * results with * ms.days (in manner of ms.day_comp)
 		 */
 		time(&now);
 		msgtm = (struct tm *) malloc(sizeof(struct tm));
 
 		if(!msgtm) {
 			/*
-			 * Ugly malloc failure 
+			 * Ugly malloc failure
 			 */
 			log_text("MAIL: Couldn't malloc struct tm!");
 			return 0;
@@ -1850,10 +1850,10 @@ static int parse_msglist(char *msglist, struct mail_selector *ms,
 	 * Take a message list, and return the appropriate mail_selector * *
 	 * * setup. For * now, msglists are quite restricted. That'll change
 	 * * * * once all this is * working. Returns 0 if couldn't parse, and
-	 * * also * * notifys player of why. 
+	 * * also * * notifys player of why.
 	 */
 	/*
-	 * Initialize the mail selector - this matches all messages 
+	 * Initialize the mail selector - this matches all messages
 	 */
 	ms->low = 0;
 	ms->high = 0;
@@ -1862,16 +1862,16 @@ static int parse_msglist(char *msglist, struct mail_selector *ms,
 	ms->days = -1;
 	ms->day_comp = 0;
 	/*
-	 * Now, parse the message list 
+	 * Now, parse the message list
 	 */
 	if(!msglist || !*msglist) {
 		/*
-		 * All messages 
+		 * All messages
 		 */
 		return 1;
 	}
 	/*
-	 * Don't mess with msglist itself 
+	 * Don't mess with msglist itself
 	 */
 	StringCopyTrunc(tbuf1, msglist, LBUF_SIZE - 1);
 	p = tbuf1;
@@ -1879,19 +1879,19 @@ static int parse_msglist(char *msglist, struct mail_selector *ms,
 		p++;
 	if(!p || !*p) {
 		return 1;				/*
-								 * all messages 
+								 * all messages
 								 */
 	}
 	if(isdigit(*p)) {
 		/*
-		 * Message or range 
+		 * Message or range
 		 */
 		q = seek_char(p, '-');
 		if(*q) {
 			/*
-			 * We have a subrange, split it up and test to see if 
-			 * 
-			 * *  * *  * * it is valid 
+			 * We have a subrange, split it up and test to see if
+			 *
+			 * *  * *  * * it is valid
 			 */
 			*q++ = '\0';
 			ms->low = atoi(p);
@@ -1901,7 +1901,7 @@ static int parse_msglist(char *msglist, struct mail_selector *ms,
 			}
 			if(!q || !*q) {
 				/*
-				 * Unbounded range 
+				 * Unbounded range
 				 */
 				ms->high = 0;
 			} else {
@@ -1913,14 +1913,14 @@ static int parse_msglist(char *msglist, struct mail_selector *ms,
 			}
 		} else {
 			/*
-			 * A single message 
+			 * A single message
 			 */
 			ms->low = ms->high = atoi(p);
 		}
 	} else {
 		switch (*p) {
 		case '-':				/*
-								 * Range with no start 
+								 * Range with no start
 								 */
 			p++;
 			if(!p || !*p) {
@@ -1934,7 +1934,7 @@ static int parse_msglist(char *msglist, struct mail_selector *ms,
 			}
 			break;
 		case '~':				/*
-								 * exact # of days old 
+								 * exact # of days old
 								 */
 			p++;
 			if(!p || !*p) {
@@ -1949,7 +1949,7 @@ static int parse_msglist(char *msglist, struct mail_selector *ms,
 			}
 			break;
 		case '<':				/*
-								 * less than # of days old 
+								 * less than # of days old
 								 */
 			p++;
 			if(!p || !*p) {
@@ -1964,7 +1964,7 @@ static int parse_msglist(char *msglist, struct mail_selector *ms,
 			}
 			break;
 		case '>':				/*
-								 * greater than # of days old 
+								 * greater than # of days old
 								 */
 			p++;
 			if(!p || !*p) {
@@ -1979,7 +1979,7 @@ static int parse_msglist(char *msglist, struct mail_selector *ms,
 			}
 			break;
 		case '#':				/*
-								 * From db# 
+								 * From db#
 								 */
 			p++;
 			if(!p || !*p) {
@@ -1993,7 +1993,7 @@ static int parse_msglist(char *msglist, struct mail_selector *ms,
 			}
 			break;
 		case '*':				/*
-								 * From player name 
+								 * From player name
 								 */
 			p++;
 			if(!p || !*p) {
@@ -2009,14 +2009,14 @@ static int parse_msglist(char *msglist, struct mail_selector *ms,
 
 /*
  * case 'a':
- * case 'A':            all messages, all folders 
+ * case 'A':            all messages, all folders
  */
 			ms->flags = M_ALL;
 			break;				/*
-								 *  FIX THIS 
+								 *  FIX THIS
 								 */
 		case 'u':				/*
-								 * Urgent, Unread 
+								 * Urgent, Unread
 								 */
 		case 'U':
 			p++;
@@ -2026,19 +2026,19 @@ static int parse_msglist(char *msglist, struct mail_selector *ms,
 			}
 			switch (*p) {
 			case 'r':			/*
-								 * Urgent 
+								 * Urgent
 								 */
 			case 'R':
 				ms->flags = M_URGENT;
 				break;
 			case 'n':			/*
-								 * Unread 
+								 * Unread
 								 */
 			case 'N':
 				ms->flags = M_MSUNREAD;
 				break;
 			default:			/*
-								 * bad 
+								 * bad
 								 */
 				notify(player, "MAIL: Invalid message specification");
 				return 0;
@@ -2046,26 +2046,26 @@ static int parse_msglist(char *msglist, struct mail_selector *ms,
 			}
 			break;
 		case 'r':				/*
-								 * read 
+								 * read
 								 */
 		case 'R':
 			ms->flags = M_ISREAD;
 			break;
 		case 'c':				/*
-								 * cleared 
+								 * cleared
 								 */
 		case 'C':
 			ms->flags = M_CLEARED;
 			break;
 		case 't':				/*
-								 * tagged 
+								 * tagged
 								 */
 		case 'T':
 			ms->flags = M_TAG;
 			break;
 		case 'm':
 		case 'M':				/*
-								 * Mass, me 
+								 * Mass, me
 								 */
 			p++;
 			if(!p || !*p) {
@@ -2088,7 +2088,7 @@ static int parse_msglist(char *msglist, struct mail_selector *ms,
 			}
 			break;
 		default:				/*
-								 * Bad news 
+								 * Bad news
 								 */
 			notify(player, "MAIL: Invalid message specification");
 			return 0;
@@ -2107,7 +2107,7 @@ void check_mail_expiration()
 	dbref thing;
 
 	/*
-	 * negative values for expirations never expire 
+	 * negative values for expirations never expire
 	 */
 	if(0 > mudconf.mail_expiration)
 		return;
@@ -2117,10 +2117,10 @@ void check_mail_expiration()
 			then = timelocal(&then_tm);
 			if(((now - then) > expire_secs) && !(M_Safe(mp))) {
 				/*
-				 * Delete this one 
+				 * Delete this one
 				 */
 				/*
-				 * head and tail of the list are special 
+				 * head and tail of the list are special
 				 */
 				if(mp->prev == NULL)
 					nhashrepl((int) mp->to, (int *) mp->next,
@@ -2128,18 +2128,18 @@ void check_mail_expiration()
 				else if(mp->next == NULL)
 					mp->prev->next = NULL;
 				/*
-				 * relink the list 
+				 * relink the list
 				 */
 				if(mp->prev != NULL)
 					mp->prev->next = mp->next;
 				if(mp->next != NULL)
 					mp->next->prev = mp->prev;
 				/*
-				 * save the pointer 
+				 * save the pointer
 				 */
 				nextp = mp->next;
 				/*
-				 * then wipe 
+				 * then wipe
 				 */
 				free((char *) mp->subject);
 				delete_mail_message(mp->number);
@@ -2156,7 +2156,7 @@ void check_mail_expiration()
 static char *status_chars(struct mail *mp)
 {
 	/*
-	 * Return a short description of message flags 
+	 * Return a short description of message flags
 	 */
 	static char res[10];
 	char *p;
@@ -2177,7 +2177,7 @@ static char *status_chars(struct mail *mp)
 static char *status_string(struct mail *mp)
 {
 	/*
-	 * Return a longer description of message flags 
+	 * Return a longer description of message flags
 	 */
 	char *tbuf1;
 
@@ -2206,27 +2206,27 @@ void check_mail(dbref player, int folder, int silent)
 {
 
 	/*
-	 * Check for new @mail 
+	 * Check for new @mail
 	 */
 	int rc;						/*
 
-								 * read messages 
+								 * read messages
 								 */
 	int uc;						/*
 
-								 * unread messages 
+								 * unread messages
 								 */
 	int cc;						/*
 
-								 * cleared messages 
+								 * cleared messages
 								 */
 	int gc;						/*
 
-								 * urgent messages 
+								 * urgent messages
 								 */
 
 	/*
-	 * just count messages 
+	 * just count messages
 	 */
 	count_mail(player, folder, &rc, &uc, &cc);
 	urgent_mail(player, folder, &gc);
@@ -2301,7 +2301,7 @@ void do_malias(dbref player, dbref cause, int key, char *arg1, char *arg2)
 		break;
 	case 7:
 		/*
-		 * empty 
+		 * empty
 		 */
 		break;
 	case 8:
@@ -2330,7 +2330,7 @@ void do_malias_send(dbref player, char *tolist, char *listto, char *subject,
 		return;
 	}
 	/*
-	 * Parse the player list 
+	 * Parse the player list
 	 */
 
 	for(k = 0; k < m->numrecep; k++) {
@@ -2341,8 +2341,8 @@ void do_malias_send(dbref player, char *tolist, char *listto, char *subject,
 					  silent);
 		} else
 			send_mail(GOD, GOD, listto, subject,	/*
-													 * Complain 
-													 * about it 
+													 * Complain
+													 * about it
 													 */
 					  add_mail_message(player,
 									   tprintf
@@ -2374,7 +2374,7 @@ struct malias *get_malias(dbref player, char *alias)
 			m = malias[i];
 			if((m->owner == player) || (m->owner == GOD)) {
 				if(!strcmp(mal, m->name))	/*
-											 * Found it! 
+											 * Found it!
 											 */
 					return m;
 			}
@@ -2426,7 +2426,7 @@ void do_malias_create(dbref player, char *alias, char *tolist)
 	i = 0;
 
 	/*
-	 * Parse the player list 
+	 * Parse the player list
 	 */
 	head = (char *) tolist;
 	while (head && *head && (i < (MALIAS_LEN - 1))) {
@@ -2449,7 +2449,7 @@ void do_malias_create(dbref player, char *alias, char *tolist)
 		spot = *tail;
 		*tail = '\0';
 		/*
-		 * Now locate a target 
+		 * Now locate a target
 		 */
 		if(!strcasecmp(head, "me"))
 			target = player;
@@ -2469,7 +2469,7 @@ void do_malias_create(dbref player, char *alias, char *tolist)
 			free_lbuf(buff);
 		}
 		/*
-		 * Get the next recip 
+		 * Get the next recip
 		 */
 		*tail = spot;
 		head = tail;
@@ -2485,7 +2485,7 @@ void do_malias_create(dbref player, char *alias, char *tolist)
 	StringCopy(malias[ma_top]->name, na);
 	malias[ma_top]->desc = (char *) malloc(strlen(na) + 1);
 	StringCopy(malias[ma_top]->desc, na);	/*
-											 * For now do this. 
+											 * For now do this.
 											 */
 	ma_top++;
 
@@ -2790,7 +2790,7 @@ static char *make_numlist(dbref player, char *arg)
 		}
 
 		/*
-		 * Get the next recip 
+		 * Get the next recip
 		 */
 		*tail = spot;
 		head = tail;
@@ -2899,7 +2899,7 @@ void mail_to_list(dbref player, char *list, char *subject, char *message,
 		}
 
 		/*
-		 * Get the next recip 
+		 * Get the next recip
 		 */
 		*tail = spot;
 		head = tail;
@@ -3080,7 +3080,7 @@ void do_malias_desc(dbref player, char *alias, char *desc)
 		return;
 	} else if((m->owner != GOD) || ExpMail(player)) {
 		free(m->desc);			/*
-								 * free it up 
+								 * free it up
 								 */
 		m->desc = (char *) malloc(sizeof(char *) * strlen(desc));
 

--- a/src/match.c
+++ b/src/match.c
@@ -1,5 +1,5 @@
 /*
- * match.c -- Routines for parsing arguments 
+ * match.c -- Routines for parsing arguments
  */
 
 #include "copyright.h"
@@ -14,22 +14,22 @@
 #include "powers.h"
 
 #define	CON_LOCAL		0x01	/*
-								 * Match is near me 
+								 * Match is near me
 								 */
 #define	CON_TYPE		0x02	/*
-								 * Match is of requested type 
+								 * Match is of requested type
 								 */
 #define	CON_LOCK		0x04	/*
-								 * I pass the lock on match 
+								 * I pass the lock on match
 								 */
 #define	CON_COMPLETE		0x08	/*
-									 * Name given is the full name 
+									 * Name given is the full name
 									 */
 #define	CON_TOKEN		0x10	/*
-								 * Name is a special token 
+								 * Name is a special token
 								 */
 #define	CON_DBREF		0x20	/*
-								 * Name is a dbref 
+								 * Name is a dbref
 								 */
 
 static MSTATE md;
@@ -37,7 +37,7 @@ static MSTATE md;
 static void promote_match(dbref what, int confidence)
 {
 	/*
-	 * Check for type and locks, if requested 
+	 * Check for type and locks, if requested
 	 */
 
 	if(md.pref_type != NOTYPE) {
@@ -48,12 +48,12 @@ static void promote_match(dbref what, int confidence)
 		MSTATE save_md;
 
 		save_match_state(&save_md);
-		if(Good_obj(what) && could_doit(md.player, what, A_LOCK));
-		confidence |= CON_LOCK;
+		if(Good_obj(what) && could_doit(md.player, what, A_LOCK))
+			confidence |= CON_LOCK;
 		restore_match_state(&save_md);
 	}
 	/*
-	 * If nothing matched, take it 
+	 * If nothing matched, take it
 	 */
 
 	if(md.count == 0) {
@@ -63,14 +63,14 @@ static void promote_match(dbref what, int confidence)
 		return;
 	}
 	/*
-	 * If confidence is lower, ignore 
+	 * If confidence is lower, ignore
 	 */
 
 	if(confidence < md.confidence) {
 		return;
 	}
 	/*
-	 * If confidence is higher, replace 
+	 * If confidence is higher, replace
 	 */
 
 	if(confidence > md.confidence) {
@@ -80,7 +80,7 @@ static void promote_match(dbref what, int confidence)
 		return;
 	}
 	/*
-	 * Equal confidence, pick randomly 
+	 * Equal confidence, pick randomly
 	 */
 
 	if(random() % 2) {
@@ -105,7 +105,7 @@ static char *munge_space_for_match(char *name)
 	q = buffer;
 	while (isspace(*p))
 		p++;					/*
-								 * remove inital spaces 
+								 * remove inital spaces
 								 */
 	while (*p) {
 		while (*p && !isspace(*p))
@@ -115,9 +115,9 @@ static char *munge_space_for_match(char *name)
 			*q++ = ' ';
 	}
 	*q = '\0';					/*
-								 * remove terminal spaces and terminate * * * 
-								 * 
-								 * * string 
+								 * remove terminal spaces and terminate * * *
+								 *
+								 * * string
 								 */
 	return (buffer);
 }
@@ -144,7 +144,7 @@ void match_player(void)
 }
 
 /*
- * returns nnn if name = #nnn, else NOTHING 
+ * returns nnn if name = #nnn, else NOTHING
  */
 
 static dbref absolute_name(int need_pound)
@@ -240,10 +240,10 @@ static void match_list(dbref first, int local)
 			return;
 		}
 		/*
-		 * Warning: make sure there are no other calls to Name() in 
+		 * Warning: make sure there are no other calls to Name() in
 		 * promote_match or its called subroutines; they
 		 * would overwrite Name()'s static buffer which is
-		 * needed by string_match(). 
+		 * needed by string_match().
 		 */
 		namebuf = (char *) PureName(first);
 
@@ -420,7 +420,7 @@ dbref match_result(void)
 }
 
 /*
- * use this if you don't care about ambiguity 
+ * use this if you don't care about ambiguity
  */
 
 dbref last_match_result(void)

--- a/src/mmdb.c
+++ b/src/mmdb.c
@@ -1,5 +1,5 @@
 /*
- i ib_rw.c 
+ i ib_rw.c
  */
 #include "copyright.h"
 #include "config.h"
@@ -46,7 +46,7 @@ struct mmdb_t *mmdb_open_read(char *filename)
         free(mmdb);
         return NULL;
     }
-    
+
 	mmdb->fd = fd;
 	mmdb->length = (statbuf.st_size + 0x3FF) & ~(0x3FF);
 	mmdb->base =
@@ -234,11 +234,11 @@ char *mmdb_read_string(struct mmdb_t *mmdb) {
     return tmp;
 }
 
-char mmdb_read_opaque(struct mmdb_t *mmdb, void *dest, int maxlength) {
+void mmdb_read_opaque(struct mmdb_t *mmdb, void *dest, int maxlength) {
     int length = mmdb_read_uint32(mmdb);
-    
+
 	if((mmdb->end - mmdb->ppos) < length)
-		return NULL;
+		return;
     if(length > maxlength) {
         memcpy(dest, mmdb->ppos, maxlength);
     } else {
@@ -247,5 +247,4 @@ char mmdb_read_opaque(struct mmdb_t *mmdb, void *dest, int maxlength) {
 	mmdb->ppos += length;
 	if(length & 3)
 		mmdb->ppos += 4 - (length & 3);
-	return dest;
 }

--- a/src/netcommon.c
+++ b/src/netcommon.c
@@ -1,5 +1,5 @@
 /*
- * netcommon.c 
+ * netcommon.c
  */
 
 /*
@@ -352,7 +352,7 @@ void clearstrings(DESC * d)
  * * queue_write: Add text to the output queue for the indicated descriptor.
  */
 
-void queue_write(DESC * d, char *b, int n)
+void queue_write(DESC * d, const char *b, int n)
 {
 	int retval;
 	if(n <= 0)
@@ -370,7 +370,7 @@ void queue_string(DESC * d, const char *s)
 	strncpy(new, s, LBUF_SIZE-1);
 	new[LBUF_SIZE-1] = '\0';
 
-	if(!Ansi(d->player) && index(s, ESC_CHAR)) 
+	if(!Ansi(d->player) && index(s, ESC_CHAR))
 	        strip_ansi_r(new, s, strlen(s));
     queue_write(d, new, strlen(new));
 }
@@ -573,7 +573,7 @@ static void announce_connect(dbref player, DESC * d)
 	DESC_ITER_PLAYER(player, dtemp) num++;
 
 	/*
-	 * Reset vacation flag 
+	 * Reset vacation flag
 	 */
 	s_Flags2(player, Flags2(player) & ~VACATION);
 
@@ -631,7 +631,7 @@ static void announce_connect(dbref player, DESC * d)
 		}
 	}
 	/*
-	 * do the zone of the player's location's possible aconnect 
+	 * do the zone of the player's location's possible aconnect
 	 */
 	if(mudconf.have_zones && ((zone = Zone(loc)) != NOTHING)) {
 		switch (Typeof(zone)) {
@@ -645,8 +645,8 @@ static void announce_connect(dbref player, DESC * d)
 			break;
 		case TYPE_ROOM:
 			/*
-			 * check every object in the room for a connect * * * 
-			 * action 
+			 * check every object in the room for a connect * * *
+			 * action
 			 */
 			DOLIST(obj, Contents(zone)) {
 				buf = atr_pget(obj, A_ACONNECT, &aowner, &aflags);
@@ -742,7 +742,7 @@ void announce_disconnect(dbref player, DESC * d, const char *reason)
 		}
 		/*
 		 * do the zone of the player's location's possible * * *
-		 * adisconnect 
+		 * adisconnect
 		 */
 		if(mudconf.have_zones && ((zone = Zone(loc)) != NOTHING)) {
 			switch (Typeof(zone)) {
@@ -756,8 +756,8 @@ void announce_disconnect(dbref player, DESC * d, const char *reason)
 				break;
 			case TYPE_ROOM:
 				/*
-				 * check every object in the room for a * * * 
-				 * connect action 
+				 * check every object in the room for a * * *
+				 * connect action
 				 */
 				DOLIST(obj, Contents(zone)) {
 					atr_temp = atr_pget(obj, A_ADISCONNECT, &aowner, &aflags);
@@ -925,8 +925,8 @@ static void dump_users(DESC * e, char *match, int key)
 	if(!match || !*match)
 		match = NULL;
 
-	
-	
+
+
 	buf = alloc_mbuf("dump_users");
 	if(key == CMD_SESSION) {
 		queue_string(e, "                               ");
@@ -970,7 +970,7 @@ static void dump_users(DESC * e, char *match, int key)
 				continue;
 
 			/*
-			 * Get choice flags for wizards 
+			 * Get choice flags for wizards
 			 */
 
 			fp = flist;
@@ -1050,7 +1050,7 @@ static void dump_users(DESC * e, char *match, int key)
 	}
 	count = rcount;				/* previous mode was .. disgusting. */
 	/*
-	 * sometimes I like the ternary operator.... 
+	 * sometimes I like the ternary operator....
 	 */
 	if (ucount)
 		sprintf(buf, "%d Visible Player%slogged in, (%d %s hidden), %d record, %s maximum.\r\n", count,
@@ -1160,7 +1160,7 @@ void init_logout_cmdtab(void)
 	/*
 	 * Make the htab bigger than the number of entries so that we find
 	 * things on the first check.  Remember that the admin can add
-	 * aliases. 
+	 * aliases.
 	 */
 
 	hashinit(&mudstate.logout_cmd_htab, 3 * HASH_FACTOR);
@@ -1220,13 +1220,13 @@ static int check_connect(DESC * d, char *msg)
 	mudstate.debug_cmd = (char *) "< check_connect >";
 
 	/*
-	 * Hide the password length from SESSION 
+	 * Hide the password length from SESSION
 	 */
 
 	d->input_tot -= (strlen(msg) + 1);
 
 	/*
-	 * Crack the command apart 
+	 * Crack the command apart
 	 */
 
 	command = alloc_lbuf("check_conn.cmd");
@@ -1250,7 +1250,7 @@ static int check_connect(DESC * d, char *msg)
 			StringCopy(password, mudconf.guest_prefix);
 		}
 		/*
-		 * See if this connection would exceed the max #players 
+		 * See if this connection would exceed the max #players
 		 */
 
 		if(mudconf.max_players < 0) {
@@ -1265,7 +1265,7 @@ static int check_connect(DESC * d, char *msg)
 		if(player == NOTHING) {
 
 			/*
-			 * Not a player, or wrong password 
+			 * Not a player, or wrong password
 			 */
 
 			queue_string(d, connect_fail);
@@ -1287,15 +1287,15 @@ static int check_connect(DESC * d, char *msg)
 				return 0;
 			}
 		} else if(((mudconf.control_flags & CF_LOGIN) &&
-				   (nplayers < mudconf.max_players)) && ((mudconf.registeredonly == Registered(player)) || !mudconf.registeredonly)
+				   (nplayers < mudconf.max_players) && (mudconf.registeredonly == Registered(player))) || !mudconf.registeredonly
 				   || WizRoy(player) || God(player)) {
-		
+
 
 			if(!strncmp(command, "cd", 2) && (Wizard(player) || God(player)))
 				s_Flags(player, Flags(player) | DARK);
 
 			/*
-			 * Logins are enabled, or wiz or god and registered player if needed 
+			 * Logins are enabled, or wiz or god and registered player if needed
 			 */
 
 			STARTLOG(LOG_LOGIN, "CON", "LOGIN") {
@@ -1326,10 +1326,10 @@ static int check_connect(DESC * d, char *msg)
 			}
 
 			/*
-			 * Give the player the MOTD file and the settable * * 
-			 * 
+			 * Give the player the MOTD file and the settable * *
+			 *
 			 * * MOTD * message(s). Use raw notifies so the
-			 * player * * * doesn't * try to match on the text. 
+			 * player * * * doesn't * try to match on the text.
 			 */
 
 			if(Guest(player)) {
@@ -1370,7 +1370,7 @@ static int check_connect(DESC * d, char *msg)
 	} else if(!strncmp(command, "cr", 2)) {
 
 		/*
-		 * Enforce game down 
+		 * Enforce game down
 		 */
 
 		if(!(mudconf.control_flags & CF_LOGIN)) {
@@ -1389,7 +1389,7 @@ static int check_connect(DESC * d, char *msg)
 		}
 
 		/*
-		 * Enforce max #players 
+		 * Enforce max #players
 		 */
 
 		if(mudconf.max_players < 0) {
@@ -1402,7 +1402,7 @@ static int check_connect(DESC * d, char *msg)
 		if(nplayers > mudconf.max_players) {
 
 			/*
-			 * Too many players on, reject the attempt 
+			 * Too many players on, reject the attempt
 			 */
 
 			failconn("CRE", "Create", "Game Full", d, R_GAMEFULL, NOTHING,
@@ -1475,16 +1475,16 @@ int do_unauth_command(DESC *d, char *command) {
 
     while(*arg && !isspace(*arg)) arg++;
 
-    if(*arg) 
+    if(*arg)
         *arg++ = '\0';
 
     cp = (NAMETAB *) hashfind(command, &mudstate.logout_cmd_htab);
-    if(*arg) 
+    if(*arg)
         *--arg = ' ';
 
-    if(!cp) 
+    if(!cp)
         return check_connect(d, command);
-    
+
     d->command_count++;
     if(!(cp->flag & CMD_NOxFIX)) {
         if(d->output_prefix) {
@@ -1563,7 +1563,7 @@ int do_command(DESC * d, char *command)
 
 
 	/*
-	 * Split off the command from the arguments 
+	 * Split off the command from the arguments
 	 */
 
 	arg = command;
@@ -1596,11 +1596,11 @@ int do_command(DESC * d, char *command)
 
    // moved this here so hudinfo doesn't spank a user's idle time or commands - jf
    d->last_time = mudstate.now;
-   
+
     cp = (NAMETAB *) hashfind(command, &mudstate.logout_cmd_htab);
 
     if(*arg)
-        *--arg = ' ';	
+        *--arg = ' ';
     if(cp == NULL) {
         d->command_count++;
         if(d->output_prefix) {

--- a/src/unparse.c
+++ b/src/unparse.c
@@ -62,7 +62,7 @@ static void unparse_boolexp1(dbref player, BOOLEXP * b, char outer_type,
 	char *tbuf, sep_ch;
 	char *buff;
 
-	if((b == TRUE_BOOLEXP)) {
+	if(b == TRUE_BOOLEXP) {
 		if(format == F_EXAMINE) {
 			safe_str((char *) "*UNLOCKED*", boolexp_buf, &buftop);
 		}


### PR DESCRIPTION
This change switches all compile warnings to be considered as errors by the compiler, and all errors to be considered as fatal (i.e. the compiler bombs out immediately). 

With these directives activate I was able to identify and address the compile warnings in this codebase. Some of these warning likely indicated bugs. As you can see in the PR some of these fixes address real issues with the code, either buffer overflows, conditions that simply cannot occur or logic errors. There is also the possibility I have changed some of the behaviour of this codebase users have expect as normal. I suspect those areas could be in the heading and facing code areas.