### PR TITLE
fetch data from companion git repositories

### DIFF
--- a/getdata.sh
+++ b/getdata.sh
@@ -1,7 +1,7 @@
 #! /bin/sh
 
 #
-# Downloads data files to the game directory, then optionally 
+# Downloads data files to the game directory, then optionally
 
 GITORG="https://github.com/KrugerHeavyIndustries"
 
@@ -12,28 +12,28 @@ set -e
 # Check for prototype game directory.
 if test ! -d game; then
 	echo "Downloading game directory from the git repository..."
-  mkdir -p game
+	mkdir -p game
 	curl -L "${GITORG}/btmux-game/tarball/master" | tar xv -C game --strip-component 1
 fi
 
 # Check for prototype maps directory.
 if test ! -d game/maps; then
 	echo "Downloading game/maps from the git repository..."
-  mkdir -p game/maps
+	mkdir -p game/maps
 	curl -L "${GITORG}/btmux-maps/tarball/master" | tar xv -C game/maps --strip-component 1
 fi
 
 # Check for prototype text directory.
 if test ! -d game/text; then
 	echo "Downloading game/text from the git repository..."
-  mkdir -p game/text
+	mkdir -p game/text
 	curl -L "${GITORG}/btmux-text/tarball/master" | tar xv -C game/text --strip-component 1
 fi
 
 # Check for prototype mechs directory.
 if test ! -d game/mechs; then
 	echo "Downloading game/mechs from the git repository..."
-  mkdir -p game/mechs
+	mkdir -p game/mechs
 	curl -L "${GITORG}/btmux-mechs/tarball/master" | tar xv -C game/mechs --strip-component 1
 fi
 

--- a/getdata.sh
+++ b/getdata.sh
@@ -2,9 +2,8 @@
 
 #
 # Downloads data files to the game directory, then optionally 
-#
 
-SVNROOT="svn://svn.code.sf.net/p/btonline-btech/code"
+GITORG="https://github.com/KrugerHeavyIndustries"
 
 # XXX: Terminate on errors.  This is sorta a lazy hack, to avoid having to
 # check exit status and recover on each command.
@@ -12,31 +11,35 @@ set -e
 
 # Check for prototype game directory.
 if test ! -d game; then
-	echo "Downloading game directory from the Subversion repository..."
-	svn co "${SVNROOT}/game/trunk" game
+	echo "Downloading game directory from the git repository..."
+  mkdir -p game
+	curl -L "${GITORG}/btmux-game/tarball/master" | tar xv -C game --strip-component 1
 fi
 
 # Check for prototype maps directory.
 if test ! -d game/maps; then
-	echo "Downloading game/maps from the Subversion repository..."
-	svn co "${SVNROOT}/maps/trunk" game/maps
+	echo "Downloading game/maps from the git repository..."
+  mkdir -p game/maps
+	curl -L "${GITORG}/btmux-maps/tarball/master" | tar xv -C game/maps --strip-component 1
 fi
 
 # Check for prototype text directory.
 if test ! -d game/text; then
-	echo "Downloading game/text from the Subversion repository..."
-	svn co "${SVNROOT}/text/trunk" game/text
+	echo "Downloading game/text from the git repository..."
+  mkdir -p game/text
+	curl -L "${GITORG}/btmux-text/tarball/master" | tar xv -C game/text --strip-component 1
 fi
 
 # Check for prototype mechs directory.
 if test ! -d game/mechs; then
-	echo "Downloading game/mechs from the Subversion repository..."
-	svn co "${SVNROOT}/mechs/trunk" game/mechs
+	echo "Downloading game/mechs from the git repository..."
+  mkdir -p game/mechs
+	curl -L "${GITORG}/btmux-mechs/tarball/master" | tar xv -C game/mechs --strip-component 1
 fi
 
 # Check if, for some bizarre reason, we still don't have a game directory.
 if test ! -d game; then
-	echo "No game directory. Please acquire one from http://sourceforge.net/projects/btonline-btech."
+	echo "No game directory. Please acquire one from http://github.com/KrugerHeavyIndustries/btmux."
 	exit 1
 fi
 


### PR DESCRIPTION
`make install` used to game fetch data from the [original Sourceforge SVN repository](https://sourceforge.net/p/btonline-btech). As that does not appear to be maintained anymore, this change causes make install to fetch data from the git repositories that hold game data alongside this git repository. Namely: 

- https://github.com/KrugerHeavyIndustries/btmux-maps
- https://github.com/KrugerHeavyIndustries/btmux-mechs
- https://github.com/KrugerHeavyIndustries/btmux-game
- https://github.com/KrugerHeavyIndustries/btmux-text

It may be that one day all the data is rolled into this repository.