### PR TITLE
fix: memory overwrite possible closing list

### DIFF
--- a/src/speech.c
+++ b/src/speech.c
@@ -565,9 +565,9 @@ void do_page(dbref player, dbref cause, int key, char *tname, char *message)
 
 			safe_str(tprintf("%d ", target), buf2, &bp2);
 			safe_str(tprintf("%s, ", Name(target)), buf1, &bp);
+			*(bp - 2) = '\0';
 			count++;
 		}
-		*(bp - 2) = '\0';
 	}
 
 	if(count == 0) {

--- a/src/speech.c
+++ b/src/speech.c
@@ -565,6 +565,10 @@ void do_page(dbref player, dbref cause, int key, char *tname, char *message)
 
 			safe_str(tprintf("%d ", target), buf2, &bp2);
 			safe_str(tprintf("%s, ", Name(target)), buf1, &bp);
+
+			/* this is terminating the string above when there is no more to add to the list
+			 * removing the ", "
+			 */
 			*(bp - 2) = '\0';
 			count++;
 		}


### PR DESCRIPTION
This fixes a memory overwrite that was possible when paging "no-one".

Used to be able to crash server (with memory address sanitisation active) using 

1. connect to server
2. login 
3. attempt page to non-existent player

`page t=crash`

random memory overwrite

```
 thread #1, queue = 'com.apple.main-thread', stop reason = Heap buffer overflow
  * frame #0: 0x00000001010cdfa0 libclang_rt.asan_osx_dynamic.dylib`__asan::AsanDie()
    frame #1: 0x00000001010e8c6f libclang_rt.asan_osx_dynamic.dylib`__sanitizer::Die() + 175
    frame #2: 0x00000001010cc197 libclang_rt.asan_osx_dynamic.dylib`__asan::ScopedInErrorReport::~ScopedInErrorReport() + 1207
    frame #3: 0x00000001010cb437 libclang_rt.asan_osx_dynamic.dylib`__asan::ReportGenericError(unsigned long, unsigned long, unsigned long, unsigned long, bool, unsigned long, unsigned int, bool) + 1719
    frame #4: 0x00000001010cc86b libclang_rt.asan_osx_dynamic.dylib`__asan_report_store1 + 43
    frame #5: 0x0000000100262fdd netmux`do_page(player=1, cause=1, key=0, tname="t", message="crash") at speech.c:570:13
    frame #6: 0x000000010001fa27 netmux`process_cmdent(cmdp=0x00000001002d7698, switchp=0x0000000000000000, player=1, cause=1, interactive=1, arg="crash", unp_command="page t", cargs=0x0000000000000000, ncargs=0) at command.c:1184:5
    frame #7: 0x000000010002285f netmux`process_command(player=1, cause=1, interactive=1, command="page t", args=0x0000000000000000, nargs=0) at command.c:1432:4
    frame #8: 0x00000001001d5387 netmux`do_command(d=0x000062900a708200, command="page t") at netcommon.c:1611:9
    frame #9: 0x00000001001d76cd netmux`run_command(d=0x000062900a708200, command="page t") at netcommon.c:1814:3
    frame #10: 0x0000000100010a34 netmux`process_input(d=0x000062900a708200) at bsd.c:661:17
    frame #11: 0x000000010000f32e netmux`accept_client_input(fd=6, event=2, arg=0x000062900a708200) at bsd.c:311:6
    frame #12: 0x00000001006b977b libevent-2.1.7.dylib`event_process_active_single_queue + 1024
    frame #13: 0x00000001006b69c8 libevent-2.1.7.dylib`event_base_loop + 1004
    frame #14: 0x0000000100012ba5 netmux`shovechars(port=5555) at bsd.c:392:2
    frame #15: 0x000000010014a471 netmux`real_main(argc=2, argv=0x00007ff7bfeff850) at game.c:1410:2
    frame #16: 0x0000000100000c72 netmux`main(argc=2, argv=0x00007ff7bfeff850) at dummy.cc:12:9
    frame #17: 0x00000001004ad52e dyld`start + 462
(lldb) 
```