### PR TITLE
fix loading empty dbs

### DIFF
--- a/btech/src/glue.c
+++ b/btech/src/glue.c
@@ -828,6 +828,14 @@ SaveSpecialObjects(int i)
 	int xcode_version = XCODE_MAGIC;
 	char target[LBUF_SIZE];
 
+	if (!xcode_tree) {
+		/* no xcode_tree means we did not actually load any "special objects"
+		 * so lets us just early exit here. This is expected when working with
+		 * a new or empty database
+		 */
+		return;
+	}
+
 	switch (i) {
 	case DUMP_KILLED:
 		snprintf(target, LBUF_SIZE, "%s.KILLED", mudconf.hcode_db);

--- a/src/rbtree.c
+++ b/src/rbtree.c
@@ -750,7 +750,7 @@ int rb_walk(rbtree bt, int how,
 {
     rbtree_node *last, *node;
     int depth = 0;
-    if(!bt->head)
+    if(!bt || !bt->head)
         return 1;
     last = NULL;
     node = bt->head;


### PR DESCRIPTION
This PR will allow the engine to load empty dbs (when building some from scratch).